### PR TITLE
add alerts and toast manager

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,6 +8,7 @@
   "rust-analyzer.cargo.features": [
     "all",
   ],
+  "rust-analyzer.cargo.target": "wasm32-unknown-unknown",
   "rust-analyzer.check.extraArgs": [
     "--all-features",
   ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -552,9 +552,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.24"
+version = "1.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16595d3be041c03b09d08d0858631facccee9221e579704070e6e9e4915d3bc7"
+checksum = "d0fc897dc1e865cc67c0e05a836d9d3f1df3cbe442aa4a9473b18e12624a4951"
 dependencies = [
  "jobserver",
  "libc",
@@ -790,7 +790,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc4feb366740ded31a004a0e4452fbf84e80ef432ecf8314c485210229672fd1"
 dependencies = [
  "bytemuck",
- "emath",
+ "emath 0.31.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "ecolor"
+version = "0.31.1"
+source = "git+https://github.com/blackberryfloat/egui.git?branch=wm%2Fallow-memory-removal#c3d444611ce8eead082e88bc921ad6fb95526f21"
+dependencies = [
+ "bytemuck",
+ "emath 0.31.1 (git+https://github.com/blackberryfloat/egui.git?branch=wm%2Fallow-memory-removal)",
 ]
 
 [[package]]
@@ -832,14 +841,13 @@ dependencies = [
 [[package]]
 name = "egui"
 version = "0.31.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25dd34cec49ab55d85ebf70139cb1ccd29c977ef6b6ba4fe85489d6877ee9ef3"
+source = "git+https://github.com/blackberryfloat/egui.git?branch=wm%2Fallow-memory-removal#c3d444611ce8eead082e88bc921ad6fb95526f21"
 dependencies = [
  "accesskit",
  "ahash",
  "bitflags 2.9.1",
- "emath",
- "epaint",
+ "emath 0.31.1 (git+https://github.com/blackberryfloat/egui.git?branch=wm%2Fallow-memory-removal)",
+ "epaint 0.31.1 (git+https://github.com/blackberryfloat/egui.git?branch=wm%2Fallow-memory-removal)",
  "log",
  "nohash-hasher",
  "profiling",
@@ -855,7 +863,7 @@ dependencies = [
  "bytemuck",
  "document-features",
  "egui",
- "epaint",
+ "epaint 0.31.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log",
  "profiling",
  "thiserror 1.0.69",
@@ -921,6 +929,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "emath"
+version = "0.31.1"
+source = "git+https://github.com/blackberryfloat/egui.git?branch=wm%2Fallow-memory-removal#c3d444611ce8eead082e88bc921ad6fb95526f21"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
 name = "endi"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -956,8 +972,23 @@ dependencies = [
  "ab_glyph",
  "ahash",
  "bytemuck",
- "ecolor",
- "emath",
+ "ecolor 0.31.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "emath 0.31.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "nohash-hasher",
+ "parking_lot",
+ "profiling",
+]
+
+[[package]]
+name = "epaint"
+version = "0.31.1"
+source = "git+https://github.com/blackberryfloat/egui.git?branch=wm%2Fallow-memory-removal#c3d444611ce8eead082e88bc921ad6fb95526f21"
+dependencies = [
+ "ab_glyph",
+ "ahash",
+ "bytemuck",
+ "ecolor 0.31.1 (git+https://github.com/blackberryfloat/egui.git?branch=wm%2Fallow-memory-removal)",
+ "emath 0.31.1 (git+https://github.com/blackberryfloat/egui.git?branch=wm%2Fallow-memory-removal)",
  "epaint_default_fonts",
  "log",
  "nohash-hasher",
@@ -968,8 +999,7 @@ dependencies = [
 [[package]]
 name = "epaint_default_fonts"
 version = "0.31.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7e7a64c02cf7a5b51e745a9e45f60660a286f151c238b9d397b3e923f5082f"
+source = "git+https://github.com/blackberryfloat/egui.git?branch=wm%2Fallow-memory-removal#c3d444611ce8eead082e88bc921ad6fb95526f21"
 
 [[package]]
 name = "equivalent"
@@ -1576,7 +1606,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.6",
+ "windows-targets 0.53.0",
 ]
 
 [[package]]
@@ -3403,11 +3433,27 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
+ "windows_i686_gnullvm 0.52.6",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1e4c7e8ceaaf9cb7d7507c974735728ab453b67ef8f18febdd7c11fe59dca8b"
+dependencies = [
+ "windows_aarch64_gnullvm 0.53.0",
+ "windows_aarch64_msvc 0.53.0",
+ "windows_i686_gnu 0.53.0",
+ "windows_i686_gnullvm 0.53.0",
+ "windows_i686_msvc 0.53.0",
+ "windows_x86_64_gnu 0.53.0",
+ "windows_x86_64_gnullvm 0.53.0",
+ "windows_x86_64_msvc 0.53.0",
 ]
 
 [[package]]
@@ -3429,6 +3475,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3445,6 +3497,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3465,10 +3523,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -3489,6 +3559,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3505,6 +3581,12 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -3525,6 +3607,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3541,6 +3629,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "winit"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -157,6 +157,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc7eb209b1518d6bb87b283c20095f5228ecda460da70b44f0802523dea6da04"
 
 [[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -589,6 +595,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "chrono"
+version = "0.4.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
+dependencies = [
+ "android-tzdata",
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "serde",
+ "wasm-bindgen",
+ "windows-link",
+]
+
+[[package]]
 name = "clipboard-win"
 version = "5.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -915,6 +936,7 @@ dependencies = [
 name = "egui_widget_ext"
 version = "0.1.0"
 dependencies = [
+ "chrono",
  "eframe",
  "egui",
 ]
@@ -1379,6 +1401,30 @@ name = "hexf-parse"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfa686283ad6dd069f105e5ab091b04c62850d3e4cf5d67debad1933f55023df"
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.63"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c919e5debc312ad217002b8048a17b7d83f80703865bbfcfebb0458b0b27d8"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "icu_collections"
@@ -3334,6 +3380,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "windows-link"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
 
 [[package]]
 name = "windows-result"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,15 +20,15 @@ checksum = "c71b1793ee61086797f5c80b6efa2b8ffa6d5dd703f118545808a7f2e27f7046"
 
 [[package]]
 name = "accesskit"
-version = "0.17.1"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3d3b8f9bae46a948369bc4a03e815d4ed6d616bd00de4051133a5019dc31c5a"
+checksum = "e25ae84c0260bdf5df07796d7cc4882460de26a2b406ec0e6c42461a723b271b"
 
 [[package]]
 name = "accesskit_atspi_common"
-version = "0.10.1"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c5dd55e6e94949498698daf4d48fb5659e824d7abec0d394089656ceaf99d4f"
+checksum = "29bd41de2e54451a8ca0dd95ebf45b54d349d29ebceb7f20be264eee14e3d477"
 dependencies = [
  "accesskit",
  "accesskit_consumer",
@@ -40,20 +40,19 @@ dependencies = [
 
 [[package]]
 name = "accesskit_consumer"
-version = "0.26.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f47983a1084940ba9a39c077a8c63e55c619388be5476ac04c804cfbd1e63459"
+checksum = "8bfae7c152994a31dc7d99b8eeac7784a919f71d1b306f4b83217e110fd3824c"
 dependencies = [
  "accesskit",
  "hashbrown",
- "immutable-chunkmap",
 ]
 
 [[package]]
 name = "accesskit_macos"
-version = "0.18.1"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7329821f3bd1101e03a7d2e03bd339e3ac0dc64c70b4c9f9ae1949e3ba8dece1"
+checksum = "692dd318ff8a7a0ffda67271c4bd10cf32249656f4e49390db0b26ca92b095f2"
 dependencies = [
  "accesskit",
  "accesskit_consumer",
@@ -65,9 +64,9 @@ dependencies = [
 
 [[package]]
 name = "accesskit_unix"
-version = "0.13.1"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcee751cc20d88678c33edaf9c07e8b693cd02819fe89053776f5313492273f5"
+checksum = "c5f7474c36606d0fe4f438291d667bae7042ea2760f506650ad2366926358fc8"
 dependencies = [
  "accesskit",
  "accesskit_atspi_common",
@@ -83,24 +82,23 @@ dependencies = [
 
 [[package]]
 name = "accesskit_windows"
-version = "0.24.1"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24fcd5d23d70670992b823e735e859374d694a3d12bfd8dd32bd3bd8bedb5d81"
+checksum = "70a042b62c9c05bf7b616f015515c17d2813f3ba89978d6f4fc369735d60700a"
 dependencies = [
  "accesskit",
  "accesskit_consumer",
  "hashbrown",
- "paste",
  "static_assertions",
  "windows",
- "windows-core",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
 name = "accesskit_winit"
-version = "0.23.1"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a6a48dad5530b6deb9fc7a52cc6c3bf72cdd9eb8157ac9d32d69f2427a5e879"
+checksum = "5c1f0d3d13113d8857542a4f8d1a1c24d1dc1527b77aee8426127f4901588708"
 dependencies = [
  "accesskit",
  "accesskit_macos",
@@ -123,7 +121,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
  "cfg-if",
- "getrandom 0.3.3",
+ "getrandom",
  "once_cell",
  "version_check",
  "zerocopy",
@@ -145,7 +143,7 @@ dependencies = [
  "log",
  "ndk",
  "ndk-context",
- "ndk-sys 0.6.0+11769913",
+ "ndk-sys",
  "num_enum",
  "thiserror 1.0.69",
 ]
@@ -210,15 +208,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "175571dd1d178ced59193a6fc02dde1b972eb0bc56c892cde9beeceac5bf0f6b"
 
 [[package]]
-name = "ash"
-version = "0.38.0+1.3.281"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bb44936d800fea8f016d7f2311c6a4f97aebd5dc86f09906139ec848cf3a46f"
-dependencies = [
- "libloading",
-]
-
-[[package]]
 name = "async-broadcast"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -254,17 +243,6 @@ dependencies = [
  "futures-lite",
  "pin-project-lite",
  "slab",
-]
-
-[[package]]
-name = "async-fs"
-version = "2.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebcd09b382f40fcd159c2d695175b2ae620ffa5f3bd6f664131efff4e8b9e04a"
-dependencies = [
- "async-lock",
- "blocking",
- "futures-lite",
 ]
 
 [[package]]
@@ -370,9 +348,9 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "atspi"
-version = "0.22.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be534b16650e35237bb1ed189ba2aab86ce65e88cc84c66f4935ba38575cecbf"
+checksum = "c83247582e7508838caf5f316c00791eee0e15c0bf743e6880585b867e16815c"
 dependencies = [
  "atspi-common",
  "atspi-connection",
@@ -381,9 +359,9 @@ dependencies = [
 
 [[package]]
 name = "atspi-common"
-version = "0.6.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1909ed2dc01d0a17505d89311d192518507e8a056a48148e3598fef5e7bb6ba7"
+checksum = "33dfc05e7cdf90988a197803bf24f5788f94f7c94a69efa95683e8ffe76cfdfb"
 dependencies = [
  "enumflags2",
  "serde",
@@ -397,9 +375,9 @@ dependencies = [
 
 [[package]]
 name = "atspi-connection"
-version = "0.6.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "430c5960624a4baaa511c9c0fcc2218e3b58f5dbcc47e6190cafee344b873333"
+checksum = "4193d51303d8332304056ae0004714256b46b6635a5c556109b319c0d3784938"
 dependencies = [
  "atspi-common",
  "atspi-proxies",
@@ -409,14 +387,13 @@ dependencies = [
 
 [[package]]
 name = "atspi-proxies"
-version = "0.6.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e6c5de3e524cf967569722446bcd458d5032348554d9a17d7d72b041ab7496"
+checksum = "d2eebcb9e7e76f26d0bcfd6f0295e1cd1e6f33bedbc5698a971db8dc43d7751c"
 dependencies = [
  "atspi-common",
  "serde",
  "zbus",
- "zvariant",
 ]
 
 [[package]]
@@ -453,21 +430,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "block"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
-
-[[package]]
-name = "block-buffer"
-version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
-dependencies = [
- "generic-array",
 ]
 
 [[package]]
@@ -620,10 +582,11 @@ dependencies = [
 
 [[package]]
 name = "codespan-reporting"
-version = "0.11.1"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
+checksum = "fe6d2e5af09e8c8ad56c969f2157a3d4238cebc7c55f0a517728c38f7b200f81"
 dependencies = [
+ "serde",
  "termcolor",
  "unicode-width",
 ]
@@ -698,15 +661,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cpufeatures"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "crc32fast"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -722,30 +676,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
-name = "crypto-common"
-version = "0.1.6"
+name = "crunchy"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
-dependencies = [
- "generic-array",
- "typenum",
-]
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "cursor-icon"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f27ae1dd37df86211c42e150270f82743308803d90a6f6e6651cd730d5e1732f"
-
-[[package]]
-name = "digest"
-version = "0.10.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
-dependencies = [
- "block-buffer",
- "crypto-common",
-]
 
 [[package]]
 name = "dispatch"
@@ -806,28 +746,19 @@ checksum = "d8b14ccef22fc6f5a8f4d7d768562a182c04ce9a3b3157b91390b52ddfdf1a76"
 
 [[package]]
 name = "ecolor"
-version = "0.31.1"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc4feb366740ded31a004a0e4452fbf84e80ef432ecf8314c485210229672fd1"
+checksum = "4a631732d995184114016fab22fc7e3faf73d6841c2d7650395fe251fbcd9285"
 dependencies = [
  "bytemuck",
- "emath 0.31.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "ecolor"
-version = "0.31.1"
-source = "git+https://github.com/blackberryfloat/egui.git?branch=wm%2Fstable-area-sizing-pass#68f4b72258f226960da2fcf92da1049e1748dd39"
-dependencies = [
- "bytemuck",
- "emath 0.31.1 (git+https://github.com/blackberryfloat/egui.git?branch=wm%2Fstable-area-sizing-pass)",
+ "emath",
 ]
 
 [[package]]
 name = "eframe"
-version = "0.31.1"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0dfe0859f3fb1bc6424c57d41e10e9093fe938f426b691e42272c2f336d915c"
+checksum = "0c790ccfbb3dd556588342463454b2b2b13909e5fdce5bc2a1432a8aa69c8b7a"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -861,30 +792,33 @@ dependencies = [
 
 [[package]]
 name = "egui"
-version = "0.31.1"
-source = "git+https://github.com/blackberryfloat/egui.git?branch=wm%2Fstable-area-sizing-pass#68f4b72258f226960da2fcf92da1049e1748dd39"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8470210c95a42cc985d9ffebfd5067eea55bdb1c3f7611484907db9639675e28"
 dependencies = [
  "accesskit",
  "ahash",
  "bitflags 2.9.1",
- "emath 0.31.1 (git+https://github.com/blackberryfloat/egui.git?branch=wm%2Fstable-area-sizing-pass)",
- "epaint 0.31.1 (git+https://github.com/blackberryfloat/egui.git?branch=wm%2Fstable-area-sizing-pass)",
+ "emath",
+ "epaint",
  "log",
  "nohash-hasher",
  "profiling",
+ "smallvec",
+ "unicode-segmentation",
 ]
 
 [[package]]
 name = "egui-wgpu"
-version = "0.31.1"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d319dfef570f699b6e9114e235e862a2ddcf75f0d1a061de9e1328d92146d820"
+checksum = "14de9942d8b9e99e2d830403c208ab1a6e052e925a7456a4f6f66d567d90de1d"
 dependencies = [
  "ahash",
  "bytemuck",
  "document-features",
  "egui",
- "epaint 0.31.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "epaint",
  "log",
  "profiling",
  "thiserror 1.0.69",
@@ -896,9 +830,9 @@ dependencies = [
 
 [[package]]
 name = "egui-winit"
-version = "0.31.1"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d9dfbb78fe4eb9c3a39ad528b90ee5915c252e77bbab9d4ebc576541ab67e13"
+checksum = "c490804a035cec9c826082894a3e1ecf4198accd3817deb10f7919108ebafab0"
 dependencies = [
  "accesskit_winit",
  "ahash",
@@ -916,9 +850,9 @@ dependencies = [
 
 [[package]]
 name = "egui_glow"
-version = "0.31.1"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "910906e3f042ea6d2378ec12a6fd07698e14ddae68aed2d819ffe944a73aab9e"
+checksum = "d44f3fd4fdc5f960c9e9ef7327c26647edc3141abf96102980647129d49358e6"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -943,17 +877,9 @@ dependencies = [
 
 [[package]]
 name = "emath"
-version = "0.31.1"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e4cadcff7a5353ba72b7fea76bf2122b5ebdbc68e8155aa56dfdea90083fe1b"
-dependencies = [
- "bytemuck",
-]
-
-[[package]]
-name = "emath"
-version = "0.31.1"
-source = "git+https://github.com/blackberryfloat/egui.git?branch=wm%2Fstable-area-sizing-pass#68f4b72258f226960da2fcf92da1049e1748dd39"
+checksum = "45f057b141e7e46340c321400be74b793543b1b213036f0f989c35d35957c32e"
 dependencies = [
  "bytemuck",
 ]
@@ -987,30 +913,15 @@ dependencies = [
 
 [[package]]
 name = "epaint"
-version = "0.31.1"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41fcc0f5a7c613afd2dee5e4b30c3e6acafb8ad6f0edb06068811f708a67c562"
+checksum = "94cca02195f0552c17cabdc02f39aa9ab6fbd815dac60ab1cd3d5b0aa6f9551c"
 dependencies = [
  "ab_glyph",
  "ahash",
  "bytemuck",
- "ecolor 0.31.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "emath 0.31.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "nohash-hasher",
- "parking_lot",
- "profiling",
-]
-
-[[package]]
-name = "epaint"
-version = "0.31.1"
-source = "git+https://github.com/blackberryfloat/egui.git?branch=wm%2Fstable-area-sizing-pass#68f4b72258f226960da2fcf92da1049e1748dd39"
-dependencies = [
- "ab_glyph",
- "ahash",
- "bytemuck",
- "ecolor 0.31.1 (git+https://github.com/blackberryfloat/egui.git?branch=wm%2Fstable-area-sizing-pass)",
- "emath 0.31.1 (git+https://github.com/blackberryfloat/egui.git?branch=wm%2Fstable-area-sizing-pass)",
+ "ecolor",
+ "emath",
  "epaint_default_fonts",
  "log",
  "nohash-hasher",
@@ -1020,8 +931,9 @@ dependencies = [
 
 [[package]]
 name = "epaint_default_fonts"
-version = "0.31.1"
-source = "git+https://github.com/blackberryfloat/egui.git?branch=wm%2Fstable-area-sizing-pass#68f4b72258f226960da2fcf92da1049e1748dd39"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8495e11ed527dff39663b8c36b6c2b2799d7e4287fb90556e455d72eca0b4d3"
 
 [[package]]
 name = "equivalent"
@@ -1170,12 +1082,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "futures-sink"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
-
-[[package]]
 name = "futures-task"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1188,24 +1094,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
  "futures-core",
- "futures-io",
  "futures-macro",
- "futures-sink",
  "futures-task",
- "memchr",
  "pin-project-lite",
  "pin-utils",
  "slab",
-]
-
-[[package]]
-name = "generic-array"
-version = "0.14.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
-dependencies = [
- "typenum",
- "version_check",
 ]
 
 [[package]]
@@ -1220,17 +1113,6 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi 0.11.1+wasi-snapshot-preview1",
-]
-
-[[package]]
-name = "getrandom"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
@@ -1238,7 +1120,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
- "wasi 0.14.2+wasi-0.2.4",
+ "wasi",
 ]
 
 [[package]]
@@ -1331,42 +1213,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "gpu-alloc"
-version = "0.6.0"
+name = "half"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbcd2dba93594b227a1f57ee09b8b9da8892c34d55aa332e034a228d0fe6a171"
+checksum = "459196ed295495a68f7d7fe1d84f6c4b7ff0e21fe3017b2f283c6fac3ad803c9"
 dependencies = [
- "bitflags 2.9.1",
- "gpu-alloc-types",
-]
-
-[[package]]
-name = "gpu-alloc-types"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98ff03b468aa837d70984d55f5d3f846f6ec31fe34bbb97c4f85219caeee1ca4"
-dependencies = [
- "bitflags 2.9.1",
-]
-
-[[package]]
-name = "gpu-descriptor"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b89c83349105e3732062a895becfc71a8f921bb71ecbbdd8ff99263e3b53a0ca"
-dependencies = [
- "bitflags 2.9.1",
- "gpu-descriptor-types",
- "hashbrown",
-]
-
-[[package]]
-name = "gpu-descriptor-types"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdf242682df893b86f33a73828fb09ca4b2d3bb6cc95249707fc684d27484b91"
-dependencies = [
- "bitflags 2.9.1",
+ "cfg-if",
+ "crunchy",
+ "num-traits",
 ]
 
 [[package]]
@@ -1414,7 +1268,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core",
+ "windows-core 0.58.0",
 ]
 
 [[package]]
@@ -1547,15 +1401,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "immutable-chunkmap"
-version = "2.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12f97096f508d54f8f8ab8957862eee2ccd628847b6217af1a335e1c44dee578"
-dependencies = [
- "arrayvec",
-]
-
-[[package]]
 name = "indexmap"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1593,7 +1438,7 @@ version = "0.1.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38f262f097c174adebe41eb73d66ae9c06b2844fb0da69969647bbddd9b0538a"
 dependencies = [
- "getrandom 0.3.3",
+ "getrandom",
  "libc",
 ]
 
@@ -1611,17 +1456,6 @@ checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "khronos-egl"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6aae1df220ece3c0ada96b8153459b67eebe9ae9212258bb0134ae60416fdf76"
-dependencies = [
- "libc",
- "libloading",
- "pkg-config",
 ]
 
 [[package]]
@@ -1645,6 +1479,12 @@ dependencies = [
  "cfg-if",
  "windows-targets 0.53.2",
 ]
+
+[[package]]
+name = "libm"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 
 [[package]]
 name = "libredox"
@@ -1698,15 +1538,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
-name = "malloc_buf"
-version = "0.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "memchr"
 version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1731,21 +1562,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "metal"
-version = "0.31.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f569fb946490b5743ad69813cb19629130ce9374034abe31614a36402d18f99e"
-dependencies = [
- "bitflags 2.9.1",
- "block",
- "core-graphics-types",
- "foreign-types",
- "log",
- "objc",
- "paste",
-]
-
-[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1757,24 +1573,26 @@ dependencies = [
 
 [[package]]
 name = "naga"
-version = "24.0.0"
+version = "25.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e380993072e52eef724eddfcde0ed013b0c023c3f0417336ed041aa9f076994e"
+checksum = "2b977c445f26e49757f9aca3631c3b8b836942cb278d69a92e7b80d3b24da632"
 dependencies = [
  "arrayvec",
  "bit-set",
  "bitflags 2.9.1",
  "cfg_aliases",
  "codespan-reporting",
+ "half",
+ "hashbrown",
  "hexf-parse",
  "indexmap",
  "log",
+ "num-traits",
+ "once_cell",
  "rustc-hash 1.1.0",
- "spirv",
  "strum",
- "termcolor",
  "thiserror 2.0.12",
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -1786,7 +1604,7 @@ dependencies = [
  "bitflags 2.9.1",
  "jni-sys",
  "log",
- "ndk-sys 0.6.0+11769913",
+ "ndk-sys",
  "num_enum",
  "raw-window-handle",
  "thiserror 1.0.69",
@@ -1800,15 +1618,6 @@ checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
 
 [[package]]
 name = "ndk-sys"
-version = "0.5.0+25.2.9519653"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c196769dd60fd4f363e11d948139556a344e79d451aeb2fa2fd040738ef7691"
-dependencies = [
- "jni-sys",
-]
-
-[[package]]
-name = "ndk-sys"
 version = "0.6.0+11769913"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee6cda3051665f1fb8d9e08fc35c96d5a244fb1be711a03b71118828afc9a873"
@@ -1818,9 +1627,9 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.29.0"
+version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
  "bitflags 2.9.1",
  "cfg-if",
@@ -1842,6 +1651,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -1863,15 +1673,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "objc"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1"
-dependencies = [
- "malloc_buf",
 ]
 
 [[package]]
@@ -2161,15 +1962,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ordered-float"
-version = "4.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
 name = "ordered-stream"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2216,12 +2008,6 @@ dependencies = [
  "smallvec",
  "windows-targets 0.52.6",
 ]
-
-[[package]]
-name = "paste"
-version = "1.0.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "percent-encoding"
@@ -2307,21 +2093,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "portable-atomic"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
+
+[[package]]
 name = "potential_utf"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5a7c30837279ca13e7c867e9e40053bc68740f988cb07f7ca6df43cc734b585"
 dependencies = [
  "zerovec",
-]
-
-[[package]]
-name = "ppv-lite86"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
-dependencies = [
- "zerocopy",
 ]
 
 [[package]]
@@ -2350,9 +2133,9 @@ checksum = "afbdc74edc00b6f6a218ca6a5364d6226a259d4b8ea1af4a0ea063f27e179f4d"
 
 [[package]]
 name = "quick-xml"
-version = "0.30.0"
+version = "0.36.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eff6510e86862b57b210fd8cbe8ed3f0d7d600b9c2863cd4549a2e033c66e956"
+checksum = "f7649a7b4df05aed9ea7ec6f628c67c9953a43869b8bc50929569b2999d443fe"
 dependencies = [
  "memchr",
  "serde",
@@ -2381,36 +2164,6 @@ name = "r-efi"
 version = "5.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
-
-[[package]]
-name = "rand"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
-dependencies = [
- "libc",
- "rand_chacha",
- "rand_core",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
-dependencies = [
- "ppv-lite86",
- "rand_core",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-dependencies = [
- "getrandom 0.2.16",
-]
 
 [[package]]
 name = "raw-window-handle"
@@ -2552,17 +2305,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha1"
-version = "0.10.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "digest",
-]
-
-[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2650,15 +2392,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "spirv"
-version = "0.3.0+sdk-1.3.268.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eda41003dc44290527a59b13432d4a0379379fa074b70174882adfbdfd917844"
-dependencies = [
- "bitflags 2.9.1",
-]
-
-[[package]]
 name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2727,7 +2460,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
 dependencies = [
  "fastrand",
- "getrandom 0.3.3",
+ "getrandom",
  "once_cell",
  "rustix 1.0.7",
  "windows-sys 0.59.0",
@@ -2892,12 +2625,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "typenum"
-version = "1.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
-
-[[package]]
 name = "uds_windows"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2925,12 +2652,6 @@ name = "unicode-width"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
-
-[[package]]
-name = "unicode-xid"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "url"
@@ -2964,12 +2685,6 @@ dependencies = [
  "same-file",
  "winapi-util",
 ]
-
-[[package]]
-name = "wasi"
-version = "0.11.1+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasi"
@@ -3204,23 +2919,24 @@ checksum = "a751b3277700db47d3e574514de2eced5e54dc8a5436a3bf7a0b248b2cee16f3"
 
 [[package]]
 name = "wgpu"
-version = "24.0.5"
+version = "25.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b0b3436f0729f6cdf2e6e9201f3d39dc95813fad61d826c1ed07918b4539353"
+checksum = "ec8fb398f119472be4d80bc3647339f56eb63b2a331f6a3d16e25d8144197dd9"
 dependencies = [
  "arrayvec",
  "bitflags 2.9.1",
  "cfg_aliases",
  "document-features",
+ "hashbrown",
  "js-sys",
  "log",
  "parking_lot",
+ "portable-atomic",
  "profiling",
  "raw-window-handle",
  "smallvec",
  "static_assertions",
  "wasm-bindgen",
- "wasm-bindgen-futures",
  "web-sys",
  "wgpu-core",
  "wgpu-hal",
@@ -3229,79 +2945,72 @@ dependencies = [
 
 [[package]]
 name = "wgpu-core"
-version = "24.0.5"
+version = "25.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f0aa306497a238d169b9dc70659105b4a096859a34894544ca81719242e1499"
+checksum = "f7b882196f8368511d613c6aeec80655160db6646aebddf8328879a88d54e500"
 dependencies = [
  "arrayvec",
+ "bit-set",
  "bit-vec",
  "bitflags 2.9.1",
  "cfg_aliases",
  "document-features",
+ "hashbrown",
  "indexmap",
  "log",
  "naga",
  "once_cell",
  "parking_lot",
+ "portable-atomic",
  "profiling",
  "raw-window-handle",
  "rustc-hash 1.1.0",
  "smallvec",
  "thiserror 2.0.12",
+ "wgpu-core-deps-windows-linux-android",
  "wgpu-hal",
  "wgpu-types",
 ]
 
 [[package]]
-name = "wgpu-hal"
-version = "24.0.4"
+name = "wgpu-core-deps-windows-linux-android"
+version = "25.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f112f464674ca69f3533248508ee30cb84c67cf06c25ff6800685f5e0294e259"
+checksum = "cba5fb5f7f9c98baa7c889d444f63ace25574833df56f5b817985f641af58e46"
 dependencies = [
- "android_system_properties",
- "arrayvec",
- "ash",
+ "wgpu-hal",
+]
+
+[[package]]
+name = "wgpu-hal"
+version = "25.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f968767fe4d3d33747bbd1473ccd55bf0f6451f55d733b5597e67b5deab4ad17"
+dependencies = [
  "bitflags 2.9.1",
- "bytemuck",
  "cfg_aliases",
- "core-graphics-types",
- "glow",
- "glutin_wgl_sys",
- "gpu-alloc",
- "gpu-descriptor",
- "js-sys",
- "khronos-egl",
- "libc",
  "libloading",
  "log",
- "metal",
  "naga",
- "ndk-sys 0.5.0+25.2.9519653",
- "objc",
- "once_cell",
- "ordered-float",
  "parking_lot",
- "profiling",
+ "portable-atomic",
  "raw-window-handle",
  "renderdoc-sys",
- "rustc-hash 1.1.0",
- "smallvec",
  "thiserror 2.0.12",
- "wasm-bindgen",
- "web-sys",
  "wgpu-types",
- "windows",
 ]
 
 [[package]]
 name = "wgpu-types"
-version = "24.0.0"
+version = "25.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50ac044c0e76c03a0378e7786ac505d010a873665e2d51383dcff8dd227dc69c"
+checksum = "2aa49460c2a8ee8edba3fca54325540d904dd85b2e086ada762767e17d06e8bc"
 dependencies = [
  "bitflags 2.9.1",
+ "bytemuck",
  "js-sys",
  "log",
+ "thiserror 2.0.12",
  "web-sys",
 ]
 
@@ -3338,12 +3047,24 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
-version = "0.58.0"
+version = "0.61.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
+checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
 dependencies = [
- "windows-core",
- "windows-targets 0.52.6",
+ "windows-collections",
+ "windows-core 0.61.2",
+ "windows-future",
+ "windows-link",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
+dependencies = [
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -3352,11 +3073,35 @@ version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
 dependencies = [
- "windows-implement",
- "windows-interface",
- "windows-result",
- "windows-strings",
+ "windows-implement 0.58.0",
+ "windows-interface 0.58.0",
+ "windows-result 0.2.0",
+ "windows-strings 0.1.0",
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
+dependencies = [
+ "windows-implement 0.60.0",
+ "windows-interface 0.59.1",
+ "windows-link",
+ "windows-result 0.3.4",
+ "windows-strings 0.4.2",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
+dependencies = [
+ "windows-core 0.61.2",
+ "windows-link",
+ "windows-threading",
 ]
 
 [[package]]
@@ -3364,6 +3109,17 @@ name = "windows-implement"
 version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3382,10 +3138,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-interface"
+version = "0.59.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+
+[[package]]
+name = "windows-numerics"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
+dependencies = [
+ "windows-core 0.61.2",
+ "windows-link",
+]
 
 [[package]]
 name = "windows-result"
@@ -3397,13 +3174,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-result"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
 name = "windows-strings"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
 dependencies = [
- "windows-result",
+ "windows-result 0.2.0",
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
@@ -3493,6 +3288,15 @@ dependencies = [
  "windows_x86_64_gnu 0.53.0",
  "windows_x86_64_gnullvm 0.53.0",
  "windows_x86_64_msvc 0.53.0",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
@@ -3790,16 +3594,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ef33da6b1660b4ddbfb3aef0ade110c8b8a781a3b6382fa5f2b5b040fd55f61"
 
 [[package]]
-name = "xdg-home"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec1cdab258fb55c0da61328dc52c8764709b249011b2cad0454c72f0bf10a1f6"
-dependencies = [
- "libc",
- "windows-sys 0.59.0",
-]
-
-[[package]]
 name = "xkbcommon-dl"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3850,13 +3644,12 @@ dependencies = [
 
 [[package]]
 name = "zbus"
-version = "4.4.0"
+version = "5.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb97012beadd29e654708a0fdb4c84bc046f537aecfde2c3ee0a9e4b4d48c725"
+checksum = "597f45e98bc7e6f0988276012797855613cd8269e23b5be62cc4e5d28b7e515d"
 dependencies = [
  "async-broadcast",
  "async-executor",
- "async-fs",
  "async-io",
  "async-lock",
  "async-process",
@@ -3867,20 +3660,16 @@ dependencies = [
  "enumflags2",
  "event-listener",
  "futures-core",
- "futures-sink",
- "futures-util",
+ "futures-lite",
  "hex",
  "nix",
  "ordered-stream",
- "rand",
  "serde",
  "serde_repr",
- "sha1",
- "static_assertions",
  "tracing",
  "uds_windows",
- "windows-sys 0.52.0",
- "xdg-home",
+ "windows-sys 0.59.0",
+ "winnow",
  "zbus_macros",
  "zbus_names",
  "zvariant",
@@ -3888,9 +3677,9 @@ dependencies = [
 
 [[package]]
 name = "zbus-lockstep"
-version = "0.4.4"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ca2c5dceb099bddaade154055c926bb8ae507a18756ba1d8963fd7b51d8ed1d"
+checksum = "29e96e38ded30eeab90b6ba88cb888d70aef4e7489b6cd212c5e5b5ec38045b6"
 dependencies = [
  "zbus_xml",
  "zvariant",
@@ -3898,9 +3687,9 @@ dependencies = [
 
 [[package]]
 name = "zbus-lockstep-macros"
-version = "0.4.4"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "709ab20fc57cb22af85be7b360239563209258430bccf38d8b979c5a2ae3ecce"
+checksum = "dc6821851fa840b708b4cbbaf6241868cabc85a2dc22f426361b0292bfc0b836"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3912,35 +3701,38 @@ dependencies = [
 
 [[package]]
 name = "zbus_macros"
-version = "4.4.0"
+version = "5.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "267db9407081e90bbfa46d841d3cbc60f59c0351838c4bc65199ecd79ab1983e"
+checksum = "e5c8e4e14dcdd9d97a98b189cd1220f30e8394ad271e8c987da84f73693862c2"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
  "syn",
+ "zbus_names",
+ "zvariant",
  "zvariant_utils",
 ]
 
 [[package]]
 name = "zbus_names"
-version = "3.0.0"
+version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b9b1fef7d021261cc16cba64c351d291b715febe0fa10dc3a443ac5a5022e6c"
+checksum = "7be68e64bf6ce8db94f63e72f0c7eb9a60d733f7e0499e628dfab0f84d6bcb97"
 dependencies = [
  "serde",
  "static_assertions",
+ "winnow",
  "zvariant",
 ]
 
 [[package]]
 name = "zbus_xml"
-version = "4.0.0"
+version = "5.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab3f374552b954f6abb4bd6ce979e6c9b38fb9d0cd7cc68a7d796e70c9f3a233"
+checksum = "589e9a02bfafb9754bb2340a9e3b38f389772684c63d9637e76b1870377bec29"
 dependencies = [
- "quick-xml 0.30.0",
+ "quick-xml 0.36.2",
  "serde",
  "static_assertions",
  "zbus_names",
@@ -4023,22 +3815,23 @@ dependencies = [
 
 [[package]]
 name = "zvariant"
-version = "4.2.0"
+version = "5.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2084290ab9a1c471c38fc524945837734fbf124487e105daec2bb57fd48c81fe"
+checksum = "d91b3680bb339216abd84714172b5138a4edac677e641ef17e1d8cb1b3ca6e6f"
 dependencies = [
  "endi",
  "enumflags2",
  "serde",
- "static_assertions",
+ "winnow",
  "zvariant_derive",
+ "zvariant_utils",
 ]
 
 [[package]]
 name = "zvariant_derive"
-version = "4.2.0"
+version = "5.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73e2ba546bda683a90652bac4a279bc146adad1386f25379cf73200d2002c449"
+checksum = "3a8c68501be459a8dbfffbe5d792acdd23b4959940fc87785fb013b32edbc208"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -4049,11 +3842,14 @@ dependencies = [
 
 [[package]]
 name = "zvariant_utils"
-version = "2.1.0"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c51bcff7cc3dbb5055396bcf774748c3dab426b4b8659046963523cee4808340"
+checksum = "e16edfee43e5d7b553b77872d99bc36afdda75c223ca7ad5e3fbecd82ca5fc34"
 dependencies = [
  "proc-macro2",
  "quote",
+ "serde",
+ "static_assertions",
  "syn",
+ "winnow",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,18 +25,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3d3b8f9bae46a948369bc4a03e815d4ed6d616bd00de4051133a5019dc31c5a"
 
 [[package]]
-name = "accesskit"
-version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e25ae84c0260bdf5df07796d7cc4882460de26a2b406ec0e6c42461a723b271b"
-
-[[package]]
 name = "accesskit_atspi_common"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c5dd55e6e94949498698daf4d48fb5659e824d7abec0d394089656ceaf99d4f"
 dependencies = [
- "accesskit 0.17.1",
+ "accesskit",
  "accesskit_consumer",
  "atspi-common",
  "serde",
@@ -50,7 +44,7 @@ version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f47983a1084940ba9a39c077a8c63e55c619388be5476ac04c804cfbd1e63459"
 dependencies = [
- "accesskit 0.17.1",
+ "accesskit",
  "hashbrown",
  "immutable-chunkmap",
 ]
@@ -61,7 +55,7 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7329821f3bd1101e03a7d2e03bd339e3ac0dc64c70b4c9f9ae1949e3ba8dece1"
 dependencies = [
- "accesskit 0.17.1",
+ "accesskit",
  "accesskit_consumer",
  "hashbrown",
  "objc2 0.5.2",
@@ -75,7 +69,7 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcee751cc20d88678c33edaf9c07e8b693cd02819fe89053776f5313492273f5"
 dependencies = [
- "accesskit 0.17.1",
+ "accesskit",
  "accesskit_atspi_common",
  "async-channel",
  "async-executor",
@@ -93,7 +87,7 @@ version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24fcd5d23d70670992b823e735e859374d694a3d12bfd8dd32bd3bd8bedb5d81"
 dependencies = [
- "accesskit 0.17.1",
+ "accesskit",
  "accesskit_consumer",
  "hashbrown",
  "paste",
@@ -108,7 +102,7 @@ version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6a48dad5530b6deb9fc7a52cc6c3bf72cdd9eb8157ac9d32d69f2427a5e879"
 dependencies = [
- "accesskit 0.17.1",
+ "accesskit",
  "accesskit_macos",
  "accesskit_unix",
  "accesskit_windows",
@@ -802,10 +796,10 @@ dependencies = [
 [[package]]
 name = "ecolor"
 version = "0.31.1"
-source = "git+https://github.com/blackberryfloat/egui.git?branch=wm%2Fallow-memory-removal#923757c1be0042b79b5b155d9e6fe93dda420f8d"
+source = "git+https://github.com/blackberryfloat/egui.git?branch=wm%2Fstable-area-sizing-pass#68f4b72258f226960da2fcf92da1049e1748dd39"
 dependencies = [
  "bytemuck",
- "emath 0.31.1 (git+https://github.com/blackberryfloat/egui.git?branch=wm%2Fallow-memory-removal)",
+ "emath 0.31.1 (git+https://github.com/blackberryfloat/egui.git?branch=wm%2Fstable-area-sizing-pass)",
 ]
 
 [[package]]
@@ -847,18 +841,16 @@ dependencies = [
 [[package]]
 name = "egui"
 version = "0.31.1"
-source = "git+https://github.com/blackberryfloat/egui.git?branch=wm%2Fallow-memory-removal#923757c1be0042b79b5b155d9e6fe93dda420f8d"
+source = "git+https://github.com/blackberryfloat/egui.git?branch=wm%2Fstable-area-sizing-pass#68f4b72258f226960da2fcf92da1049e1748dd39"
 dependencies = [
- "accesskit 0.19.0",
+ "accesskit",
  "ahash",
  "bitflags 2.9.1",
- "emath 0.31.1 (git+https://github.com/blackberryfloat/egui.git?branch=wm%2Fallow-memory-removal)",
- "epaint 0.31.1 (git+https://github.com/blackberryfloat/egui.git?branch=wm%2Fallow-memory-removal)",
+ "emath 0.31.1 (git+https://github.com/blackberryfloat/egui.git?branch=wm%2Fstable-area-sizing-pass)",
+ "epaint 0.31.1 (git+https://github.com/blackberryfloat/egui.git?branch=wm%2Fstable-area-sizing-pass)",
  "log",
  "nohash-hasher",
  "profiling",
- "smallvec",
- "unicode-segmentation",
 ]
 
 [[package]]
@@ -939,7 +931,7 @@ dependencies = [
 [[package]]
 name = "emath"
 version = "0.31.1"
-source = "git+https://github.com/blackberryfloat/egui.git?branch=wm%2Fallow-memory-removal#923757c1be0042b79b5b155d9e6fe93dda420f8d"
+source = "git+https://github.com/blackberryfloat/egui.git?branch=wm%2Fstable-area-sizing-pass#68f4b72258f226960da2fcf92da1049e1748dd39"
 dependencies = [
  "bytemuck",
 ]
@@ -990,13 +982,13 @@ dependencies = [
 [[package]]
 name = "epaint"
 version = "0.31.1"
-source = "git+https://github.com/blackberryfloat/egui.git?branch=wm%2Fallow-memory-removal#923757c1be0042b79b5b155d9e6fe93dda420f8d"
+source = "git+https://github.com/blackberryfloat/egui.git?branch=wm%2Fstable-area-sizing-pass#68f4b72258f226960da2fcf92da1049e1748dd39"
 dependencies = [
  "ab_glyph",
  "ahash",
  "bytemuck",
- "ecolor 0.31.1 (git+https://github.com/blackberryfloat/egui.git?branch=wm%2Fallow-memory-removal)",
- "emath 0.31.1 (git+https://github.com/blackberryfloat/egui.git?branch=wm%2Fallow-memory-removal)",
+ "ecolor 0.31.1 (git+https://github.com/blackberryfloat/egui.git?branch=wm%2Fstable-area-sizing-pass)",
+ "emath 0.31.1 (git+https://github.com/blackberryfloat/egui.git?branch=wm%2Fstable-area-sizing-pass)",
  "epaint_default_fonts",
  "log",
  "nohash-hasher",
@@ -1007,7 +999,7 @@ dependencies = [
 [[package]]
 name = "epaint_default_fonts"
 version = "0.31.1"
-source = "git+https://github.com/blackberryfloat/egui.git?branch=wm%2Fallow-memory-removal#923757c1be0042b79b5b155d9e6fe93dda420f8d"
+source = "git+https://github.com/blackberryfloat/egui.git?branch=wm%2Fstable-area-sizing-pass#68f4b72258f226960da2fcf92da1049e1748dd39"
 
 [[package]]
 name = "equivalent"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,12 +25,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3d3b8f9bae46a948369bc4a03e815d4ed6d616bd00de4051133a5019dc31c5a"
 
 [[package]]
+name = "accesskit"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e25ae84c0260bdf5df07796d7cc4882460de26a2b406ec0e6c42461a723b271b"
+
+[[package]]
 name = "accesskit_atspi_common"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c5dd55e6e94949498698daf4d48fb5659e824d7abec0d394089656ceaf99d4f"
 dependencies = [
- "accesskit",
+ "accesskit 0.17.1",
  "accesskit_consumer",
  "atspi-common",
  "serde",
@@ -44,7 +50,7 @@ version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f47983a1084940ba9a39c077a8c63e55c619388be5476ac04c804cfbd1e63459"
 dependencies = [
- "accesskit",
+ "accesskit 0.17.1",
  "hashbrown",
  "immutable-chunkmap",
 ]
@@ -55,7 +61,7 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7329821f3bd1101e03a7d2e03bd339e3ac0dc64c70b4c9f9ae1949e3ba8dece1"
 dependencies = [
- "accesskit",
+ "accesskit 0.17.1",
  "accesskit_consumer",
  "hashbrown",
  "objc2 0.5.2",
@@ -69,7 +75,7 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcee751cc20d88678c33edaf9c07e8b693cd02819fe89053776f5313492273f5"
 dependencies = [
- "accesskit",
+ "accesskit 0.17.1",
  "accesskit_atspi_common",
  "async-channel",
  "async-executor",
@@ -87,7 +93,7 @@ version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24fcd5d23d70670992b823e735e859374d694a3d12bfd8dd32bd3bd8bedb5d81"
 dependencies = [
- "accesskit",
+ "accesskit 0.17.1",
  "accesskit_consumer",
  "hashbrown",
  "paste",
@@ -102,7 +108,7 @@ version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6a48dad5530b6deb9fc7a52cc6c3bf72cdd9eb8157ac9d32d69f2427a5e879"
 dependencies = [
- "accesskit",
+ "accesskit 0.17.1",
  "accesskit_macos",
  "accesskit_unix",
  "accesskit_windows",
@@ -112,9 +118,9 @@ dependencies = [
 
 [[package]]
 name = "adler2"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "ahash"
@@ -488,15 +494,15 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.17.0"
+version = "3.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
+checksum = "793db76d6187cd04dff33004d8e6c9cc4e05cd330500379d2394209271b4aeee"
 
 [[package]]
 name = "bytemuck"
-version = "1.23.0"
+version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9134a6ef01ce4b366b50689c94f82c14bc72bc5d0386829828a2e2752ef7958c"
+checksum = "5c76a5792e44e4abe34d3abf15636779261d45a7450612059293d1d2cfc63422"
 dependencies = [
  "bytemuck_derive",
 ]
@@ -552,9 +558,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.25"
+version = "1.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0fc897dc1e865cc67c0e05a836d9d3f1df3cbe442aa4a9473b18e12624a4951"
+checksum = "d487aa071b5f64da6f19a3e848e3578944b726ee5a4854b82172f02aa876bfdc"
 dependencies = [
  "jobserver",
  "libc",
@@ -569,9 +575,9 @@ checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
 name = "cfg-if"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
 
 [[package]]
 name = "cfg_aliases"
@@ -796,7 +802,7 @@ dependencies = [
 [[package]]
 name = "ecolor"
 version = "0.31.1"
-source = "git+https://github.com/blackberryfloat/egui.git?branch=wm%2Fallow-memory-removal#c3d444611ce8eead082e88bc921ad6fb95526f21"
+source = "git+https://github.com/blackberryfloat/egui.git?branch=wm%2Fallow-memory-removal#923757c1be0042b79b5b155d9e6fe93dda420f8d"
 dependencies = [
  "bytemuck",
  "emath 0.31.1 (git+https://github.com/blackberryfloat/egui.git?branch=wm%2Fallow-memory-removal)",
@@ -841,9 +847,9 @@ dependencies = [
 [[package]]
 name = "egui"
 version = "0.31.1"
-source = "git+https://github.com/blackberryfloat/egui.git?branch=wm%2Fallow-memory-removal#c3d444611ce8eead082e88bc921ad6fb95526f21"
+source = "git+https://github.com/blackberryfloat/egui.git?branch=wm%2Fallow-memory-removal#923757c1be0042b79b5b155d9e6fe93dda420f8d"
 dependencies = [
- "accesskit",
+ "accesskit 0.19.0",
  "ahash",
  "bitflags 2.9.1",
  "emath 0.31.1 (git+https://github.com/blackberryfloat/egui.git?branch=wm%2Fallow-memory-removal)",
@@ -851,6 +857,8 @@ dependencies = [
  "log",
  "nohash-hasher",
  "profiling",
+ "smallvec",
+ "unicode-segmentation",
 ]
 
 [[package]]
@@ -931,7 +939,7 @@ dependencies = [
 [[package]]
 name = "emath"
 version = "0.31.1"
-source = "git+https://github.com/blackberryfloat/egui.git?branch=wm%2Fallow-memory-removal#c3d444611ce8eead082e88bc921ad6fb95526f21"
+source = "git+https://github.com/blackberryfloat/egui.git?branch=wm%2Fallow-memory-removal#923757c1be0042b79b5b155d9e6fe93dda420f8d"
 dependencies = [
  "bytemuck",
 ]
@@ -944,9 +952,9 @@ checksum = "a3d8a32ae18130a3c84dd492d4215c3d913c3b07c6b63c2eb3eb7ff1101ab7bf"
 
 [[package]]
 name = "enumflags2"
-version = "0.7.11"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba2f4b465f5318854c6f8dd686ede6c0a9dc67d4b1ac241cf0eb51521a309147"
+checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
 dependencies = [
  "enumflags2_derive",
  "serde",
@@ -954,9 +962,9 @@ dependencies = [
 
 [[package]]
 name = "enumflags2_derive"
-version = "0.7.11"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc4caf64a58d7a6d65ab00639b046ff54399a39f5f2554728895ace4b297cd79"
+checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -982,7 +990,7 @@ dependencies = [
 [[package]]
 name = "epaint"
 version = "0.31.1"
-source = "git+https://github.com/blackberryfloat/egui.git?branch=wm%2Fallow-memory-removal#c3d444611ce8eead082e88bc921ad6fb95526f21"
+source = "git+https://github.com/blackberryfloat/egui.git?branch=wm%2Fallow-memory-removal#923757c1be0042b79b5b155d9e6fe93dda420f8d"
 dependencies = [
  "ab_glyph",
  "ahash",
@@ -999,7 +1007,7 @@ dependencies = [
 [[package]]
 name = "epaint_default_fonts"
 version = "0.31.1"
-source = "git+https://github.com/blackberryfloat/egui.git?branch=wm%2Fallow-memory-removal#c3d444611ce8eead082e88bc921ad6fb95526f21"
+source = "git+https://github.com/blackberryfloat/egui.git?branch=wm%2Fallow-memory-removal#923757c1be0042b79b5b155d9e6fe93dda420f8d"
 
 [[package]]
 name = "equivalent"
@@ -1061,9 +1069,9 @@ dependencies = [
 
 [[package]]
 name = "flate2"
-version = "1.1.1"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ced92e76e966ca2fd84c8f7aa01a4aea65b0eb6648d72f7c8f3e2764a67fece"
+checksum = "4a3d7db9596fecd151c5f638c0ee5d5bd487b6e0ea232e5dc96d5250f6f94b1d"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -1204,7 +1212,7 @@ checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi 0.11.1+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -1349,9 +1357,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.3"
+version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84b26c544d002229e640969970a2e74021aadf6e2f96372b9c58eff97de08eb3"
+checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
 dependencies = [
  "foldhash",
 ]
@@ -1364,9 +1372,9 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f154ce46856750ed433c8649605bf7ed2de3bc35fd9d2a9f30cddd873c80cb08"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -1379,15 +1387,6 @@ name = "hexf-parse"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfa686283ad6dd069f105e5ab091b04c62850d3e4cf5d67debad1933f55023df"
-
-[[package]]
-name = "home"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
-dependencies = [
- "windows-sys 0.59.0",
-]
 
 [[package]]
 name = "icu_collections"
@@ -1595,9 +1594,9 @@ checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
 
 [[package]]
 name = "libc"
-version = "0.2.172"
+version = "0.2.173"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
+checksum = "d8cfeafaffdbc32176b64fb251369d52ea9f0a8fbc6f8759edffef7b525d64bb"
 
 [[package]]
 name = "libloading"
@@ -1606,7 +1605,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if",
- "windows-targets 0.53.0",
+ "windows-targets 0.53.2",
 ]
 
 [[package]]
@@ -1617,7 +1616,7 @@ checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
  "bitflags 2.9.1",
  "libc",
- "redox_syscall 0.5.12",
+ "redox_syscall 0.5.13",
 ]
 
 [[package]]
@@ -1671,9 +1670,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.4"
+version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 
 [[package]]
 name = "memmap2"
@@ -1710,9 +1709,9 @@ dependencies = [
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3be647b768db090acb35d5ec5db2b0e1f1de11133ca123b9eacf5137868f892a"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
  "simd-adler32",
@@ -2175,7 +2174,7 @@ checksum = "bc838d2a56b5b1a6c25f55575dfc605fabb63bb2365f6c2353ef9159aa69e4a5"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.12",
+ "redox_syscall 0.5.13",
  "smallvec",
  "windows-targets 0.52.6",
 ]
@@ -2392,9 +2391,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.12"
+version = "0.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "928fca9cf2aa042393a8325b9ead81d2f0df4cb12e1e24cef072922ccd99c5af"
+checksum = "0d04b7d0ee6b4a0207a0a7adb104d23ecb0b47d6beae7152d0fa34b692b29fd6"
 dependencies = [
  "bitflags 2.9.1",
 ]
@@ -2548,12 +2547,9 @@ checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
 
 [[package]]
 name = "slab"
-version = "0.4.9"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
-dependencies = [
- "autocfg",
-]
+checksum = "04dc19736151f35336d325007ac991178d504a119863a2fcb3758cdb5e52c50d"
 
 [[package]]
 name = "slotmap"
@@ -2566,9 +2562,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.15.0"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "smithay-client-toolkit"
@@ -2666,9 +2662,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.101"
+version = "2.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ce2b7fc941b3a24138a0a7cf8e858bfc6a992e7978a068a5c760deb0ed43caf"
+checksum = "e4307e30089d6fd6aff212f2da3a1f9e32f3223b1f010fb09b7c95f90f3ca1e8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2796,15 +2792,15 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.9"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3da5db5a963e24bc68be8b17b6fa82814bb22ee8660f192bb182771d498f09a3"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
 
 [[package]]
 name = "toml_edit"
-version = "0.22.26"
+version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "310068873db2c5b3e7659d2cc35d21855dbafa50d1ce336397c666e3cb08137e"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
  "indexmap",
  "toml_datetime",
@@ -2824,9 +2820,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.28"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
+checksum = "1b1ffbcf9c6f6b99d386e7444eb608ba646ae452a36b39737deb9663b610f662"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2835,9 +2831,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.33"
+version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
+checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
 dependencies = [
  "once_cell",
 ]
@@ -2933,9 +2929,9 @@ dependencies = [
 
 [[package]]
 name = "wasi"
-version = "0.11.0+wasi-snapshot-preview1"
+version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasi"
@@ -3148,12 +3144,11 @@ dependencies = [
 
 [[package]]
 name = "webbrowser"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5df295f8451142f1856b1bd86a606dfe9587d439bc036e319c827700dbd555e"
+checksum = "aaf4f3c0ba838e82b4e5ccc4157003fb8c324ee24c058470ffb82820becbde98"
 dependencies = [
  "core-foundation 0.10.1",
- "home",
  "jni",
  "log",
  "ndk-context",
@@ -3442,9 +3437,9 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.53.0"
+version = "0.53.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1e4c7e8ceaaf9cb7d7507c974735728ab453b67ef8f18febdd7c11fe59dca8b"
+checksum = "c66f69fcc9ce11da9966ddb31a40968cad001c5bedeb5c2b82ede4253ab48aef"
 dependencies = [
  "windows_aarch64_gnullvm 0.53.0",
  "windows_aarch64_msvc 0.53.0",
@@ -3690,9 +3685,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.7.10"
+version = "0.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06928c8748d81b05c9be96aad92e1b6ff01833332f281e8cfca3be4b35fc9ec"
+checksum = "74c7b26e3480b707944fc872477815d29a8e429d2f93a1ce000f5fa84a15cbcd"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,8 @@ keywords = ["egui", "widget", "gui", "ui", "extension"]
 documentation = "https://docs.rs/egui_widget_ext"
 
 [dependencies]
-egui = "0.31.1"
+# egui = "0.31.1"
+egui = { git = "https://github.com/blackberryfloat/egui.git", branch = "wm/allow-memory-removal"}
 
 [features]
 toggle_switch=[]
@@ -20,6 +21,9 @@ alert_manager=["alert"]
 toast=[]
 toast_manager=["toast"]
 all = ["alert_manager", "alert", "toggle_switch", "toast_manager", "toast"]
+
+[patch.crates-io]
+egui = { git = "https://github.com/blackberryfloat/egui.git", branch = "wm/allow-memory-removal" }
 
 [dev-dependencies]
 eframe = "0.31.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,8 @@ toggle_switch=[]
 alert=[]
 alert_manager=["alert"]
 toast=[]
-all = ["alert_manager", "alert", "toggle_switch", "toast"]
+toast_manager=["toast"]
+all = ["alert_manager", "alert", "toggle_switch", "toast_manager", "toast"]
 
 [dev-dependencies]
 eframe = "0.31.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,9 @@ egui = "0.31.1"
 [features]
 toggle_switch=[]
 alert=[]
+alert_manager=["alert"]
 toast=[]
-all = ["alert", "toggle_switch", "toast"]
+all = ["alert_manager", "alert", "toggle_switch", "toast"]
 
 [dev-dependencies]
 eframe = "0.31.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["egui", "widget", "gui", "ui", "extension"]
 documentation = "https://docs.rs/egui_widget_ext"
 
 [dependencies]
-egui = "0.31.1"
+egui = "0.32"
 chrono = { version = "0.4", features = ["wasmbind", "serde"] }
 
 [features]
@@ -22,11 +22,8 @@ toast=[]
 toast_manager=["toast"]
 all = ["alert_manager", "alert", "toggle_switch", "toast_manager", "toast"]
 
-[patch.crates-io]
-egui = { git = "https://github.com/blackberryfloat/egui.git", branch = "wm/stable-area-sizing-pass" }
-
 [dev-dependencies]
-eframe = "0.31.1"
+eframe = "0.32"
 
 [package.metadata.docs.rs]
 features = ["all"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ toast_manager=["toast"]
 all = ["alert_manager", "alert", "toggle_switch", "toast_manager", "toast"]
 
 [patch.crates-io]
-egui = { git = "https://github.com/blackberryfloat/egui.git", branch = "wm/allow-memory-removal" }
+egui = { git = "https://github.com/blackberryfloat/egui.git", branch = "wm/stable-area-sizing-pass" }
 
 [dev-dependencies]
 eframe = "0.31.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ documentation = "https://docs.rs/egui_widget_ext"
 
 [dependencies]
 egui = "0.31.1"
+chrono = { version = "0.4", features = ["wasmbind", "serde"] }
 
 [features]
 toggle_switch=[]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,7 @@ keywords = ["egui", "widget", "gui", "ui", "extension"]
 documentation = "https://docs.rs/egui_widget_ext"
 
 [dependencies]
-# egui = "0.31.1"
-egui = { git = "https://github.com/blackberryfloat/egui.git", branch = "wm/allow-memory-removal"}
+egui = "0.31.1"
 
 [features]
 toggle_switch=[]

--- a/examples/alert_manager.rs
+++ b/examples/alert_manager.rs
@@ -57,44 +57,39 @@ impl eframe::App for AlertManagerApp {
                 if ui.button("Anchor: Top Center").clicked() {
                     self.anchor = Align2::CENTER_TOP;
                     self.alerts
-                        .insert(0, (AlertLevel::Info, "Anchored to Top Center".into()));
+                        .push((AlertLevel::Info, "Anchored to Top Center".into()));
                 }
                 if ui.button("Anchor: Bottom Center").clicked() {
                     self.anchor = Align2::CENTER_BOTTOM;
                     self.alerts
-                        .insert(0, (AlertLevel::Warning, "Anchored to Bottom Center".into()));
+                        .push((AlertLevel::Warning, "Anchored to Bottom Center".into()));
                 }
                 if ui.button("Anchor: Top Left").clicked() {
                     self.anchor = Align2::LEFT_TOP;
                     self.alerts
-                        .insert(0, (AlertLevel::Error, "Anchored to Top Left".into()));
+                        .push((AlertLevel::Error, "Anchored to Top Left".into()));
                 }
                 if ui.button("Anchor: Bottom Right").clicked() {
                     self.anchor = Align2::RIGHT_BOTTOM;
                     self.alerts
-                        .insert(0, (AlertLevel::Success, "Anchored to Bottom Right".into()));
+                        .push((AlertLevel::Success, "Anchored to Bottom Right".into()));
                 }
                 if ui.button("Toggle Side Panel Alerts").clicked() {
                     self.show_side_panel = !self.show_side_panel;
                     if self.show_side_panel {
                         self.alerts
-                            .insert(0, (AlertLevel::Info, "Side panel alerts enabled!".into()));
+                            .push((AlertLevel::Info, "Side panel alerts enabled!".into()));
                     } else {
-                        self.alerts.insert(
-                            0,
-                            (AlertLevel::Warning, "Side panel alerts disabled!".into()),
-                        );
+                        self.alerts
+                            .push((AlertLevel::Warning, "Side panel alerts disabled!".into()));
                     }
                 }
                 if ui.button("Add Many Alerts").clicked() {
                     for i in 0..10 {
-                        self.alerts.insert(
-                            0,
-                            (
-                                AlertLevel::Info,
-                                format!("Bulk alert #{i} (scroll to see more)"),
-                            ),
-                        );
+                        self.alerts.push((
+                            AlertLevel::Info,
+                            format!("Bulk alert #{} (scroll to see more)", i),
+                        ));
                     }
                 }
             });

--- a/examples/alert_manager.rs
+++ b/examples/alert_manager.rs
@@ -5,30 +5,45 @@
 //! positions and in different UI regions. Use the buttons to trigger alerts in
 //! various configurations and see how the alert manager handles stacking, scrolling,
 //! and dismissal.
+//!
+//! ## Example
+//! Run this example with:
+//! ```sh
+//! cargo run --example alert_manager
+//! ```
+//!
+//! This will open a window demonstrating the alert manager's capabilities.
 
 use eframe::egui;
 use egui::{Align2, CentralPanel, Pos2, SidePanel, TopBottomPanel};
 use egui_widget_ext::{AlertLevel, AlertManager};
 
+/// Main application struct for the Alert Manager demo.
 struct AlertManagerApp {
+    /// List of alerts to be managed by the AlertManager.
     alerts: Vec<(AlertLevel, String)>,
+    /// Current anchor position for the alert manager.
     anchor: Align2,
+    /// Whether the side panel for alerts is currently shown.
     show_side_panel: bool,
+    /// Optional width for the alert boxes.
     alert_width: Option<f32>, // Make width optional
 }
 
 impl Default for AlertManagerApp {
+    /// Provides default values for the app state.
     fn default() -> Self {
         Self {
-            alerts: vec![],
-            anchor: Align2::CENTER_TOP,
-            show_side_panel: false,
-            alert_width: None, // Default: not set
+            alerts: vec![],             // Start with no alerts
+            anchor: Align2::CENTER_TOP, // Default anchor
+            show_side_panel: false,     // Side panel hidden by default
+            alert_width: None,          // Default: not set
         }
     }
 }
 
 impl AlertManagerApp {
+    /// Create a new app instance (used by eframe).
     fn new(_cc: &eframe::CreationContext<'_>) -> Self {
         Self::default()
     }
@@ -36,6 +51,7 @@ impl AlertManagerApp {
 
 impl eframe::App for AlertManagerApp {
     fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
+        // Support various UI elements to exercise the AlertManager functionality.
         TopBottomPanel::top("top_panel").show(ctx, |ui| {
             ui.horizontal(|ui| {
                 if ui.button("Anchor: Top Center").clicked() {
@@ -117,6 +133,7 @@ impl eframe::App for AlertManagerApp {
         });
 
         if self.show_side_panel {
+            // Show side panel with alerts
             SidePanel::left("side_panel").show(ctx, |ui| {
                 ui.set_width(250.0);
                 ui.heading("Side Panel");
@@ -134,6 +151,7 @@ impl eframe::App for AlertManagerApp {
             });
         }
 
+        // Track cursor position in the bottom panel for debug purposes
         TopBottomPanel::bottom("bottom_panel").show(ctx, |ui| {
             let pos: Option<Pos2> = ctx.input(|i| i.pointer.hover_pos());
             if let Some(pos) = pos {
@@ -146,6 +164,7 @@ impl eframe::App for AlertManagerApp {
             }
         });
 
+        // Demostrated an alert manager in the central panel
         CentralPanel::default().show(ctx, |ui| {
             ui.heading("Alert Manager Demo");
             ui.label("Use the buttons above to trigger alerts in different positions.");

--- a/examples/alert_manager.rs
+++ b/examples/alert_manager.rs
@@ -136,13 +136,13 @@ impl eframe::App for AlertManagerApp {
                     self.alerts
                         .push((AlertLevel::Warning, "Alert in side panel!".into()));
                 }
-                let mut alert_manager = AlertManager::new(&mut self.alerts, "side_panel")
+                let mut manager = AlertManager::new(&mut self.alerts, "side_panel")
                     .anchor(Align2::LEFT_TOP)
                     .max_height(200.0);
                 if let Some(width) = self.alert_width {
-                    alert_manager = alert_manager.width(width);
+                    manager = manager.width(width);
                 }
-                ui.add(alert_manager);
+                ui.add(manager);
             });
         }
 
@@ -164,12 +164,11 @@ impl eframe::App for AlertManagerApp {
             ui.heading("Alert Manager Demo");
             ui.label("Use the buttons above to trigger alerts in different positions.");
             if !self.show_side_panel {
-                let mut alert_manager =
-                    AlertManager::new(&mut self.alerts, "main").anchor(self.anchor);
+                let mut manager = AlertManager::new(&mut self.alerts, "main").anchor(self.anchor);
                 if let Some(width) = self.alert_width {
-                    alert_manager = alert_manager.width(width);
+                    manager = manager.width(width);
                 }
-                ui.add(alert_manager);
+                ui.add(manager);
             }
         });
     }

--- a/examples/alert_manager.rs
+++ b/examples/alert_manager.rs
@@ -1,0 +1,174 @@
+//! # Alert Manager Demo Example
+//!
+//! This example demonstrates the usage of the `AlertManager` widget from the
+//! `egui_widget_ext` crate. It shows how to display alerts with different anchor
+//! positions and in different UI regions. Use the buttons to trigger alerts in
+//! various configurations and see how the alert manager handles stacking, scrolling,
+//! and dismissal.
+
+use eframe::egui;
+use egui::{Align2, CentralPanel, Pos2, SidePanel, TopBottomPanel};
+use egui_widget_ext::{AlertLevel, AlertManager};
+
+struct AlertManagerApp {
+    alerts: Vec<(AlertLevel, String)>,
+    anchor: Align2,
+    show_side_panel: bool,
+    alert_width: Option<f32>, // Make width optional
+}
+
+impl Default for AlertManagerApp {
+    fn default() -> Self {
+        Self {
+            alerts: vec![],
+            anchor: Align2::CENTER_TOP,
+            show_side_panel: false,
+            alert_width: None, // Default: not set
+        }
+    }
+}
+
+impl AlertManagerApp {
+    fn new(_cc: &eframe::CreationContext<'_>) -> Self {
+        Self::default()
+    }
+}
+
+impl eframe::App for AlertManagerApp {
+    fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
+        TopBottomPanel::top("top_panel").show(ctx, |ui| {
+            ui.horizontal(|ui| {
+                if ui.button("Anchor: Top Center").clicked() {
+                    self.anchor = Align2::CENTER_TOP;
+                    self.alerts
+                        .insert(0, (AlertLevel::Info, "Anchored to Top Center".into()));
+                }
+                if ui.button("Anchor: Bottom Center").clicked() {
+                    self.anchor = Align2::CENTER_BOTTOM;
+                    self.alerts
+                        .insert(0, (AlertLevel::Warning, "Anchored to Bottom Center".into()));
+                }
+                if ui.button("Anchor: Top Left").clicked() {
+                    self.anchor = Align2::LEFT_TOP;
+                    self.alerts
+                        .insert(0, (AlertLevel::Error, "Anchored to Top Left".into()));
+                }
+                if ui.button("Anchor: Bottom Right").clicked() {
+                    self.anchor = Align2::RIGHT_BOTTOM;
+                    self.alerts
+                        .insert(0, (AlertLevel::Success, "Anchored to Bottom Right".into()));
+                }
+                if ui.button("Toggle Side Panel Alerts").clicked() {
+                    self.show_side_panel = !self.show_side_panel;
+                    if self.show_side_panel {
+                        self.alerts
+                            .insert(0, (AlertLevel::Info, "Side panel alerts enabled!".into()));
+                    } else {
+                        self.alerts.insert(
+                            0,
+                            (AlertLevel::Warning, "Side panel alerts disabled!".into()),
+                        );
+                    }
+                }
+                if ui.button("Add Many Alerts").clicked() {
+                    for i in 0..10 {
+                        self.alerts.insert(
+                            0,
+                            (
+                                AlertLevel::Info,
+                                format!("Bulk alert #{i} (scroll to see more)"),
+                            ),
+                        );
+                    }
+                }
+            });
+            ui.separator();
+            ui.horizontal(|ui| {
+                ui.label("Alert Width:");
+                // Use a temporary variable for editing
+                let mut width = self.alert_width.unwrap_or(300.0);
+                let response = ui.add(egui::DragValue::new(&mut width).speed(1.0));
+                if response.changed() {
+                    self.alert_width = Some(width);
+                }
+                if ui.button("Set Alert Width").clicked() {
+                    self.alert_width = Some(width);
+                    self.alerts.insert(
+                        0,
+                        (AlertLevel::Info, format!("Alert width set to {:.0}", width)),
+                    );
+                }
+                if ui.button("Clear Width").clicked() {
+                    self.alert_width = None;
+                    self.alerts.insert(
+                        0,
+                        (
+                            AlertLevel::Info,
+                            "Alert width cleared (using default)".into(),
+                        ),
+                    );
+                }
+                if let Some(w) = self.alert_width {
+                    ui.label(format!("Current: {:.0}", w));
+                } else {
+                    ui.label("Current: default");
+                }
+            });
+        });
+
+        if self.show_side_panel {
+            SidePanel::left("side_panel").show(ctx, |ui| {
+                ui.set_width(250.0);
+                ui.heading("Side Panel");
+                if ui.button("Add Side Alert").clicked() {
+                    self.alerts
+                        .push((AlertLevel::Warning, "Alert in side panel!".into()));
+                }
+                let mut alert_manager = AlertManager::new(&mut self.alerts, "side_panel")
+                    .anchor(Align2::LEFT_TOP)
+                    .max_height(200.0);
+                if let Some(width) = self.alert_width {
+                    alert_manager = alert_manager.width(width);
+                }
+                ui.add(alert_manager);
+            });
+        }
+
+        TopBottomPanel::bottom("bottom_panel").show(ctx, |ui| {
+            let pos: Option<Pos2> = ctx.input(|i| i.pointer.hover_pos());
+            if let Some(pos) = pos {
+                ui.label(format!(
+                    "Cursor position: x = {:.1}, y = {:.1}",
+                    pos.x, pos.y
+                ));
+            } else {
+                ui.label("Cursor position: <not hovering>");
+            }
+        });
+
+        CentralPanel::default().show(ctx, |ui| {
+            ui.heading("Alert Manager Demo");
+            ui.label("Use the buttons above to trigger alerts in different positions.");
+            if !self.show_side_panel {
+                let mut alert_manager =
+                    AlertManager::new(&mut self.alerts, "main").anchor(self.anchor);
+                if let Some(width) = self.alert_width {
+                    alert_manager = alert_manager.width(width);
+                }
+                ui.add(alert_manager);
+            }
+        });
+    }
+}
+
+fn main() -> eframe::Result<()> {
+    let native_options = eframe::NativeOptions {
+        viewport: egui::ViewportBuilder::default().with_maximized(true),
+        ..Default::default()
+    };
+    eframe::run_native(
+        "Alert Manager Demo",
+        native_options,
+        Box::new(|cc| Ok(Box::new(AlertManagerApp::new(cc)))),
+    )
+}

--- a/examples/alert_manager.rs
+++ b/examples/alert_manager.rs
@@ -147,7 +147,9 @@ impl eframe::App for AlertManagerApp {
                         .unwrap()
                         .push(Alert::new("Alert in side panel!").with_level(AlertLevel::Warning));
                 }
-                let mut manager = AlertManager::new(&mut self.alerts, "side_panel")
+                let mut alerts_guard = self.alerts.try_lock().unwrap();
+                let alerts = alerts_guard.as_mut();
+                let mut manager = AlertManager::new(alerts, "side_panel")
                     .anchor(Align2::LEFT_TOP)
                     .max_height(200.0);
                 if let Some(width) = self.alert_width {
@@ -175,7 +177,9 @@ impl eframe::App for AlertManagerApp {
             ui.heading("Alert Manager Demo");
             ui.label("Use the buttons above to trigger alerts in different positions.");
             if !self.show_side_panel {
-                let mut manager = AlertManager::new(&mut self.alerts, "main").anchor(self.anchor);
+                let mut alerts_guard = self.alerts.try_lock().unwrap();
+                let alerts = alerts_guard.as_mut();
+                let mut manager = AlertManager::new(alerts, "main").anchor(self.anchor);
                 if let Some(width) = self.alert_width {
                     manager = manager.width(width);
                 }

--- a/examples/alerts.rs
+++ b/examples/alerts.rs
@@ -16,21 +16,13 @@
 //! This file is intended for demonstration and manual testing purposes only.
 
 use eframe::egui;
-
 use egui_widget_ext::{Alert, AlertLevel, alert};
 
-fn main() -> eframe::Result<()> {
-    let native_options = eframe::NativeOptions {
-        viewport: egui::ViewportBuilder::default().with_maximized(true),
-        ..Default::default()
-    };
-    eframe::run_native(
-        "Alert Demo",
-        native_options,
-        Box::new(|cc| Ok(Box::new(AlertsApp::new(cc)))),
-    )
+struct AlertsApp {
+    state: AppState,
 }
 
+#[derive(Default)]
 struct AppState {
     show_error: bool,
     show_error_long: bool,
@@ -42,45 +34,31 @@ struct AppState {
     show_success_long: bool,
 }
 
-struct AlertsApp {
-    state: AppState,
-}
-
-impl Default for AlertsApp {
-    fn default() -> Self {
-        Self {
-            state: AppState {
-                show_error: true,
-                show_error_long: true,
-                show_warning: true,
-                show_warning_long: true,
-                show_info: true,
-                show_info_long: true,
-                show_success: true,
-                show_success_long: true,
-            },
-        }
-    }
-}
-
 impl AlertsApp {
     fn new(_cc: &eframe::CreationContext<'_>) -> Self {
-        Self::default()
+        Self {
+            state: AppState::default(),
+        }
     }
 }
 
 impl eframe::App for AlertsApp {
     fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
         egui::CentralPanel::default().show(ctx, |ui| {
-            ui.add(Alert::new("Welcome to the Alert Demo! This is not closeable.").with_level(AlertLevel::Info).can_close(false));
+            ui.add(
+                Alert::new(
+                    "Welcome to the Alert Demo! This is not closeable and has a fixed width!",
+                )
+                .with_level(AlertLevel::Info)
+                .can_close(false)
+                .width(400.0),
+            );
             if self.state.show_error {
-                // Short error alert using the Alert struct directly
-                use egui_widget_ext::Alert;
                 ui.add(
                     Alert::new("This is an error alert!")
                         .with_level(AlertLevel::Error)
                         .corner_radius(8)
-                        .inner_margin(12)
+                        .inner_margin(12),
                 )
                 .clicked()
                 .then(|| {
@@ -88,10 +66,21 @@ impl eframe::App for AlertsApp {
                 });
             }
             if self.state.show_error_long {
-                // Very long error alert using the convenience function
                 ui.add(alert(
                     AlertLevel::Error,
-                    "ULTRA LONG ERROR ALERT: This is an extremely, almost absurdly long error alert message. Its purpose is to push the boundaries of the alert widget's text wrapping capabilities. The message continues with more and more text, describing in excruciating detail every possible scenario in which an error might occur, including but not limited to network failures, disk errors, memory leaks, unexpected panics, user misconfigurations, hardware malfunctions, cosmic rays, and even the heat death of the universe. If you can still read this message without horizontal scrolling or text overflowing outside the alert box, then the alert widget is truly robust. This message should wrap gracefully, maintaining readability and layout integrity no matter how much text is present. Keep adding more text to ensure that the alert box grows vertically and never horizontally, always respecting the boundaries of the parent UI container. Congratulations if you made it this far!",
+                    "ULTRA LONG ERROR ALERT: This is an extremely, almost absurdly long error \
+                    alert message. Its purpose is to push the boundaries of the alert widget's \
+                    text wrapping capabilities. The message continues with more and more text, \
+                    describing in excruciating detail every possible scenario in which an error \
+                    might occur, including but not limited to network failures, disk errors, \
+                    memory leaks, unexpected panics, user misconfigurations, hardware malfunctions, \
+                    cosmic rays, and even the heat death of the universe. If you can still read \
+                    this message without horizontal scrolling or text overflowing outside the alert \
+                    box, then the alert widget is truly robust. This message should wrap gracefully, \
+                    maintaining readability and layout integrity no matter how much text is present. \
+                    Keep adding more text to ensure that the alert box grows vertically and never \
+                    horizontally, always respecting the boundaries of the parent UI container. \
+                    Congratulations if you made it this far!",
                 ))
                 .clicked()
                 .then(|| {
@@ -99,12 +88,10 @@ impl eframe::App for AlertsApp {
                 });
             }
             if self.state.show_warning {
-                // Short warning alert using the Alert struct directly
-                use egui_widget_ext::Alert;
                 ui.add(
                     Alert::new("This is a warning alert!")
                         .with_level(AlertLevel::Warning)
-                        .corner_radius(8)
+                        .corner_radius(8),
                 )
                 .clicked()
                 .then(|| {
@@ -112,10 +99,16 @@ impl eframe::App for AlertsApp {
                 });
             }
             if self.state.show_warning_long {
-                // Very long warning alert using the convenience function
                 ui.add(alert(
                     AlertLevel::Warning,
-                    "ULTRA LONG WARNING ALERT: This warning alert is so long that it might make you wonder if there is any end to it. The purpose is to ensure that the alert widget can handle even the most verbose and unnecessarily detailed warning messages, such as those that might be generated by an overzealous logging system or a particularly talkative developer. The text should wrap, never overflow, and always remain readable. If you see this message stretching off the edge of the window, something is wrong. Otherwise, everything is working as intended!",
+                    "ULTRA LONG WARNING ALERT: This warning alert is so long that it might make \
+                    you wonder if there is any end to it. The purpose is to ensure that the alert \
+                    widget can handle even the most verbose and unnecessarily detailed warning \
+                    messages, such as those that might be generated by an overzealous logging \
+                    system or a particularly talkative developer. The text should wrap, never \
+                    overflow, and always remain readable. If you see this message stretching off \
+                    the edge of the window, something is wrong. Otherwise, everything is working \
+                    as intended!",
                 ))
                 .clicked()
                 .then(|| {
@@ -123,7 +116,6 @@ impl eframe::App for AlertsApp {
                 });
             }
             if self.state.show_info {
-                // Short info alert
                 ui.add(alert(
                     AlertLevel::Info,
                     "This is an info alert!",
@@ -134,10 +126,15 @@ impl eframe::App for AlertsApp {
                 });
             }
             if self.state.show_info_long {
-                // Very long info alert
                 ui.add(alert(
                     AlertLevel::Info,
-                    "ULTRA LONG INFO ALERT: This informational alert contains an extraordinary amount of information, far more than any reasonable user would ever want to read in a single sitting. It is designed to test the absolute limits of the alert widget's ability to wrap and display text. If you can read this entire message without any part of it being cut off or overflowing its container, then the widget is performing admirably. Keep an eye out for any layout issues as the text continues to grow and grow, seemingly without end.",
+                    "ULTRA LONG INFO ALERT: This informational alert contains an extraordinary \
+                    amount of information, far more than any reasonable user would ever want to \
+                    read in a single sitting. It is designed to test the absolute limits of the \
+                    alert widget's ability to wrap and display text. If you can read this entire \
+                    message without any part of it being cut off or overflowing its container, \
+                    then the widget is performing admirably. Keep an eye out for any layout issues \
+                    as the text continues to grow and grow, seemingly without end.",
                 ))
                 .clicked()
                 .then(|| {
@@ -145,7 +142,6 @@ impl eframe::App for AlertsApp {
                 });
             }
             if self.state.show_success {
-                // Short success alert
                 ui.add(alert(
                     AlertLevel::Success,
                     "This is a success alert!",
@@ -156,10 +152,15 @@ impl eframe::App for AlertsApp {
                 });
             }
             if self.state.show_success_long {
-                // Very long success alert
                 ui.add(alert(
                     AlertLevel::Success,
-                    "ULTRA LONG SUCCESS ALERT: Congratulations! Not only have you succeeded, but you have done so in such a spectacular fashion that the success message itself cannot be contained in a single line. This message is intentionally verbose, overflowing with praise and accolades, to ensure that the alert widget can handle even the most exuberant celebrations of user achievement. The text should wrap, the alert box should expand vertically, and the user should be able to bask in the glory of their accomplishment without any UI issues.",
+                    "ULTRA LONG SUCCESS ALERT: Congratulations! Not only have you succeeded, but \
+                    you have done so in such a spectacular fashion that the success message itself \
+                    cannot be contained in a single line. This message is intentionally verbose, \
+                    overflowing with praise and accolades, to ensure that the alert widget can \
+                    handle even the most exuberant celebrations of user achievement. The text \
+                    should wrap, the alert box should expand vertically, and the user should be \
+                    able to bask in the glory of their accomplishment without any UI issues.",
                 ))
                 .clicked()
                 .then(|| {
@@ -168,4 +169,16 @@ impl eframe::App for AlertsApp {
             }
         });
     }
+}
+
+fn main() -> eframe::Result<()> {
+    let native_options = eframe::NativeOptions {
+        viewport: egui::ViewportBuilder::default().with_maximized(true),
+        ..Default::default()
+    };
+    eframe::run_native(
+        "Alert Demo",
+        native_options,
+        Box::new(|cc| Ok(Box::new(AlertsApp::new(cc)))),
+    )
 }

--- a/examples/alerts.rs
+++ b/examples/alerts.rs
@@ -22,7 +22,6 @@ struct AlertsApp {
     state: AppState,
 }
 
-#[derive(Default)]
 struct AppState {
     show_error: bool,
     show_error_long: bool,
@@ -32,6 +31,21 @@ struct AppState {
     show_info_long: bool,
     show_success: bool,
     show_success_long: bool,
+}
+
+impl Default for AppState {
+    fn default() -> Self {
+        Self {
+            show_error: true,
+            show_error_long: true,
+            show_warning: true,
+            show_warning_long: true,
+            show_info: true,
+            show_info_long: true,
+            show_success: true,
+            show_success_long: true,
+        }
+    }
 }
 
 impl AlertsApp {

--- a/examples/toast_manager.rs
+++ b/examples/toast_manager.rs
@@ -1,0 +1,134 @@
+//! # Toast Manager Demo Example
+//!
+//! This example demonstrates the usage of the `ToastManager` widget from the
+//! `egui_widget_ext` crate. It shows how to display toast notifications with different durations
+//! and how to trigger them from the UI. Toasts are transient messages that disappear automatically.
+//!
+//! ## Example
+//! Run this example with:
+//! ```sh
+//! cargo run --example toast_manager
+//! ```
+//!
+//! This will open a window demonstrating the toast manager's capabilities.
+
+use eframe::egui;
+use egui::{CentralPanel, TopBottomPanel};
+use egui_widget_ext::{Toast, ToastManager};
+use std::collections::VecDeque;
+
+struct ToastManagerApp {
+    /// List of toasts to be managed by the ToastManager.
+    toasts: VecDeque<Toast>,
+    /// Maximum number of toasts to display at once.
+    max_toasts: usize,
+    /// Anchor position for the toast area.
+    anchor: egui::Align2,
+}
+
+impl Default for ToastManagerApp {
+    fn default() -> Self {
+        Self {
+            toasts: VecDeque::new(),
+            max_toasts: 4,
+            anchor: egui::Align2::RIGHT_BOTTOM,
+        }
+    }
+}
+
+impl ToastManagerApp {
+    fn new(_cc: &eframe::CreationContext<'_>) -> Self {
+        Self::default()
+    }
+}
+
+impl eframe::App for ToastManagerApp {
+    fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
+        // Always repaint so toasts can expire
+        ctx.request_repaint_after(std::time::Duration::from_millis(100));
+
+        TopBottomPanel::top("top_panel").show(ctx, |ui| {
+            ui.horizontal(|ui| {
+                if ui.button("Show Info Toast").clicked() {
+                    self.toasts.push_back(
+                        Toast::new("This is an info toast!")
+                            .with_color(egui::Color32::from_rgb(200, 200, 255))
+                            .duration(std::time::Duration::from_secs(3)),
+                    );
+                }
+                if ui.button("Show Success Toast").clicked() {
+                    self.toasts.push_back(
+                        Toast::new("Success!")
+                            .with_color(egui::Color32::LIGHT_GREEN)
+                            .duration(std::time::Duration::from_secs(2)),
+                    );
+                }
+                if ui.button("Show Error Toast").clicked() {
+                    self.toasts.push_back(
+                        Toast::new("Something went wrong!")
+                            .with_color(egui::Color32::LIGHT_RED)
+                            .duration(std::time::Duration::from_secs(4)),
+                    );
+                }
+                if ui.button("Show Many Toasts").clicked() {
+                    for i in 0..5 {
+                        self.toasts.push_back(
+                            Toast::new(&format!("Toast #{i}"))
+                                .duration(std::time::Duration::from_secs(2 + i)),
+                        );
+                    }
+                }
+            });
+            ui.separator();
+            ui.label("Toast Manager Settings:");
+            ui.horizontal(|ui| {
+                ui.label("Max Toasts:");
+                ui.add(egui::DragValue::new(&mut self.max_toasts).range(1..=10));
+            });
+            ui.horizontal(|ui| {
+                ui.label("Anchor:");
+                let anchors = [
+                    ("Top Left", egui::Align2::LEFT_TOP),
+                    ("Top Right", egui::Align2::RIGHT_TOP),
+                    ("Bottom Left", egui::Align2::LEFT_BOTTOM),
+                    ("Bottom Right", egui::Align2::RIGHT_BOTTOM),
+                    ("Center Top", egui::Align2::CENTER_TOP),
+                    ("Center Bottom", egui::Align2::CENTER_BOTTOM),
+                ];
+                for (label, anchor) in anchors.iter() {
+                    if ui
+                        .selectable_label(self.anchor == *anchor, *label)
+                        .clicked()
+                    {
+                        self.anchor = *anchor;
+                    }
+                }
+            });
+        });
+
+        CentralPanel::default().show(ctx, |ui| {
+            ui.heading("Toast Manager Demo");
+            ui.label(
+                "Use the buttons above to trigger toasts. Toasts will appear in the selected \
+anchor location and disappear automatically.",
+            );
+            ui.add(
+                ToastManager::new(&mut self.toasts, "main")
+                    .max_toasts(self.max_toasts)
+                    .anchor(self.anchor),
+            );
+        });
+    }
+}
+
+fn main() -> eframe::Result<()> {
+    let native_options = eframe::NativeOptions {
+        viewport: egui::ViewportBuilder::default().with_maximized(true),
+        ..Default::default()
+    };
+    eframe::run_native(
+        "Toast Manager Demo",
+        native_options,
+        Box::new(|cc| Ok(Box::new(ToastManagerApp::new(cc)))),
+    )
+}

--- a/examples/toast_manager.rs
+++ b/examples/toast_manager.rs
@@ -16,10 +16,11 @@ use eframe::egui;
 use egui::{CentralPanel, TopBottomPanel};
 use egui_widget_ext::{Toast, ToastManager};
 use std::collections::VecDeque;
+use std::sync::Mutex;
 
 struct ToastManagerApp {
     /// List of toasts to be managed by the ToastManager.
-    toasts: VecDeque<Toast>,
+    toasts: Mutex<VecDeque<Toast>>,
     /// Maximum number of toasts to display at once.
     max_toasts: usize,
     /// Anchor position for the toast area.
@@ -29,7 +30,7 @@ struct ToastManagerApp {
 impl Default for ToastManagerApp {
     fn default() -> Self {
         Self {
-            toasts: VecDeque::new(),
+            toasts: Mutex::new(VecDeque::new()),
             max_toasts: 4,
             anchor: egui::Align2::RIGHT_BOTTOM,
         }
@@ -48,23 +49,24 @@ impl eframe::App for ToastManagerApp {
         ctx.request_repaint_after(std::time::Duration::from_millis(100));
 
         TopBottomPanel::top("top_panel").show(ctx, |ui| {
+            let mut toasts = self.toasts.lock().unwrap();
             ui.horizontal(|ui| {
                 if ui.button("Show Info Toast").clicked() {
-                    self.toasts.push_back(
+                    toasts.push_back(
                         Toast::new("This is an info toast!")
                             .with_color(egui::Color32::from_rgb(200, 200, 255))
                             .duration(std::time::Duration::from_secs(3)),
                     );
                 }
                 if ui.button("Show Success Toast").clicked() {
-                    self.toasts.push_back(
+                    toasts.push_back(
                         Toast::new("Success!")
                             .with_color(egui::Color32::LIGHT_GREEN)
                             .duration(std::time::Duration::from_secs(2)),
                     );
                 }
                 if ui.button("Show Error Toast").clicked() {
-                    self.toasts.push_back(
+                    toasts.push_back(
                         Toast::new("Something went wrong!")
                             .with_color(egui::Color32::LIGHT_RED)
                             .duration(std::time::Duration::from_secs(4)),
@@ -72,7 +74,7 @@ impl eframe::App for ToastManagerApp {
                 }
                 if ui.button("Show Many Toasts").clicked() {
                     for i in 0..5 {
-                        self.toasts.push_back(
+                        toasts.push_back(
                             Toast::new(&format!("Toast #{i}"))
                                 .duration(std::time::Duration::from_secs(2 + i)),
                         );

--- a/examples/toast_manager.rs
+++ b/examples/toast_manager.rs
@@ -16,6 +16,7 @@ use eframe::egui;
 use egui::{CentralPanel, TopBottomPanel};
 use egui_widget_ext::{Toast, ToastManager};
 use std::collections::VecDeque;
+use std::ops::DerefMut;
 use std::sync::Mutex;
 
 struct ToastManagerApp {
@@ -49,7 +50,8 @@ impl eframe::App for ToastManagerApp {
         ctx.request_repaint_after(std::time::Duration::from_millis(100));
 
         TopBottomPanel::top("top_panel").show(ctx, |ui| {
-            let mut toasts = self.toasts.lock().unwrap();
+            let mut toasts_guard = self.toasts.try_lock().unwrap();
+            let toasts = toasts_guard.deref_mut();
             ui.horizontal(|ui| {
                 if ui.button("Show Info Toast").clicked() {
                     toasts.push_back(
@@ -114,8 +116,10 @@ impl eframe::App for ToastManagerApp {
                 "Use the buttons above to trigger toasts. Toasts will appear in the selected \
 anchor location and disappear automatically.",
             );
+            let mut toasts_guard = self.toasts.try_lock().unwrap();
+            let toasts = toasts_guard.deref_mut();
             ui.add(
-                ToastManager::new(&mut self.toasts, "main")
+                ToastManager::new(toasts, "main")
                     .max_toasts(self.max_toasts)
                     .anchor(self.anchor),
             );

--- a/examples/toast_manager.rs
+++ b/examples/toast_manager.rs
@@ -57,28 +57,28 @@ impl eframe::App for ToastManagerApp {
                     toasts.push_back(
                         Toast::new("This is an info toast!")
                             .with_color(egui::Color32::from_rgb(200, 200, 255))
-                            .duration(std::time::Duration::from_secs(3)),
+                            .duration(chrono::Duration::seconds(3)),
                     );
                 }
                 if ui.button("Show Success Toast").clicked() {
                     toasts.push_back(
                         Toast::new("Success!")
                             .with_color(egui::Color32::LIGHT_GREEN)
-                            .duration(std::time::Duration::from_secs(2)),
+                            .duration(chrono::Duration::seconds(2)),
                     );
                 }
                 if ui.button("Show Error Toast").clicked() {
                     toasts.push_back(
                         Toast::new("Something went wrong!")
                             .with_color(egui::Color32::LIGHT_RED)
-                            .duration(std::time::Duration::from_secs(4)),
+                            .duration(chrono::Duration::seconds(4)),
                     );
                 }
                 if ui.button("Show Many Toasts").clicked() {
                     for i in 0..5 {
                         toasts.push_back(
                             Toast::new(&format!("Toast #{i}"))
-                                .duration(std::time::Duration::from_secs(2 + i)),
+                                .duration(chrono::Duration::seconds(2 + i)),
                         );
                     }
                 }

--- a/examples/toasts.rs
+++ b/examples/toasts.rs
@@ -9,8 +9,7 @@
 //! cargo run --example toasts
 //! ```
 
-use std::time::Duration;
-
+use chrono::Duration;
 use eframe::egui;
 use egui::{Align2, Color32, Context, Vec2};
 use egui_widget_ext::Toast;
@@ -44,7 +43,7 @@ impl eframe::App for ToastsApp {
                 if ui.button("8 sec Long Toast").clicked() {
                     self.toasts.push(
                         Toast::new("This toast will last for 8 seconds!")
-                            .duration(Duration::from_secs(8)),
+                            .duration(Duration::seconds(8)),
                     );
                 }
             });
@@ -66,7 +65,7 @@ impl eframe::App for ToastsApp {
 
             // Ensure toasts expire even if there's no user input
             if !self.toasts.is_empty() {
-                ctx.request_repaint_after(Duration::from_millis(200));
+                ctx.request_repaint_after(std::time::Duration::from_millis(200));
             }
         });
     }

--- a/src/alert.rs
+++ b/src/alert.rs
@@ -47,7 +47,7 @@ pub enum AlertLevel {
 /// and the corner radius. The alert box always includes a close ("✕") button.
 ///
 /// Use the [`alert`] function for a convenient way to create an alert with a given level and message.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Alert {
     /// The background color of the alert box.
     color: Color32,

--- a/src/alert.rs
+++ b/src/alert.rs
@@ -151,6 +151,11 @@ impl Alert {
             AlertLevel::Error => Color32::LIGHT_RED,
         }
     }
+
+    /// Expose alert message for external access.
+    pub fn get_message(&self) -> &str {
+        &self.message
+    }
 }
 
 impl Widget for Alert {

--- a/src/alert.rs
+++ b/src/alert.rs
@@ -187,7 +187,7 @@ impl Widget for Alert {
 /// - `message`: The message to display inside the alert box.
 ///
 /// # Returns
-/// Returns an [`egui::Widget`] closure. When invoked, it returns an [`egui::Response`] for the alert box.
+/// Returns an [`Alert`] widget configured with the specified level and message.
 ///
 /// # Example
 /// ```
@@ -198,6 +198,6 @@ impl Widget for Alert {
 /// });
 /// # });
 /// ```
-pub fn alert(level: AlertLevel, message: &str) -> impl Widget + '_ {
-    move |ui: &mut Ui| ui.add(Alert::new(message).with_level(level))
+pub fn alert(level: AlertLevel, message: &str) -> Alert {
+    Alert::new(message).with_level(level)
 }

--- a/src/alert.rs
+++ b/src/alert.rs
@@ -19,6 +19,8 @@
 //! - [`Alert`]: Struct for configuring and displaying the alert widget.
 //! - [`alert`]: Convenience function for creating an alert widget.
 
+use std::hash::Hash;
+
 use egui::{Button, Color32, CornerRadius, Frame, Label, Margin, RichText, Stroke, Ui, Widget};
 
 /// Represents the severity level of an alert. Determines the background color and semantic meaning
@@ -63,6 +65,19 @@ pub struct Alert {
     can_close: bool,
     /// Optional width constraint for the alert box.
     width: Option<f32>,
+}
+
+impl Hash for Alert {
+    /// Hash the alert's properties to ensure consistent behavior in hash maps and sets.
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.color.hash(state);
+        self.message.hash(state);
+        self.inner_margin.hash(state);
+        self.outer_margin.hash(state);
+        self.corner_radius.hash(state);
+        self.can_close.hash(state);
+        self.width.unwrap_or(-1.0).to_bits().hash(state);
+    }
 }
 
 impl Default for Alert {

--- a/src/alert.rs
+++ b/src/alert.rs
@@ -51,6 +51,8 @@ pub enum AlertLevel {
 /// Use the [`alert`] function for a convenient way to create an alert with a given level and message.
 #[derive(Debug, Clone, PartialEq)]
 pub struct Alert {
+    /// The severity level of the alert.
+    level: AlertLevel,
     /// The background color of the alert box.
     color: Color32,
     /// The message displayed in the alert box.
@@ -70,6 +72,7 @@ pub struct Alert {
 impl Hash for Alert {
     /// Hash the alert's properties to ensure consistent behavior in hash maps and sets.
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.level.hash(state);
         self.color.hash(state);
         self.message.hash(state);
         self.inner_margin.hash(state);
@@ -84,6 +87,7 @@ impl Default for Alert {
     /// Creates a default alert with a generic error color and message.
     fn default() -> Self {
         Alert {
+            level: AlertLevel::Info,
             color: Color32::from_rgb(255, 200, 200),
             message: "No message provided".to_string(),
             inner_margin: 10,
@@ -98,8 +102,10 @@ impl Default for Alert {
 impl Alert {
     /// Create a new alert with the given message and default info color.
     pub fn new(message: &str) -> Self {
-        let color = Self::level_to_color(AlertLevel::Info);
+        let level = AlertLevel::Info;
+        let color = Self::level_to_color(level);
         Self {
+            level,
             color,
             message: message.to_string(),
             ..Default::default()
@@ -108,6 +114,7 @@ impl Alert {
 
     /// Set the alert's severity level, which determines its background color.
     pub fn with_level(mut self, level: AlertLevel) -> Self {
+        self.level = level;
         self.color = Self::level_to_color(level);
         self
     }
@@ -155,6 +162,11 @@ impl Alert {
     /// Expose alert message for external access.
     pub fn get_message(&self) -> &str {
         &self.message
+    }
+
+    /// Get the alert's severity level.
+    pub fn get_level(&self) -> AlertLevel {
+        self.level
     }
 }
 

--- a/src/alert_manager.rs
+++ b/src/alert_manager.rs
@@ -1,0 +1,279 @@
+//! # Alert Manager Widget Module
+//!
+//! This module provides an `AlertManager` widget for managing and displaying a stack of alert messages
+//! in an egui application. The `AlertManager` is designed to help you present multiple alerts with
+//! consistent styling, positioning, and dismissal behavior.
+//!
+//! ## Usage
+//!
+//! The `AlertManager` takes a mutable reference to a `Vec<(AlertLevel, String)>` representing the current
+//! alerts to display. It provides builder-style methods to configure margins, corner radius, width, anchor
+//! alignment, custom position, anchor offset, and maximum height for the alert area. Each alert is rendered
+//! using the `Alert` widget, and closed alerts are automatically removed from the vector.
+//!
+//! **Recommended:**  
+//! Place the `AlertManager` at the root level of your egui widget tree (such as inside your `CentralPanel`,
+//! or as a top-level overlay) to ensure that alerts are positioned and layered correctly above
+//! your main content. However, you can technically use it anywhere in your widget hierarchy if you
+//! want to scope alerts to a specific region or panel.
+//!
+//! ## Example
+//! ```rust
+//! # use egui_widget_ext::{AlertManager, AlertLevel};
+//! # use egui::{CentralPanel, Context};
+//! # fn ui_example(ctx: &Context, alerts: &mut Vec<(AlertLevel, String)>) {
+//! CentralPanel::default().show(ctx, |ui| {
+//!     AlertManager::new(alerts)
+//!         .corner_radius(8)
+//!         .width(400.0)
+//!         .anchor(egui::Align2::CENTER_TOP)
+//!         .max_height(300.0)
+//!         .ui(ui);
+//! });
+//! # }
+//! ```
+//!
+//! ## Features
+//! - Shared styling for all alerts (margin, corner radius, width, etc.)
+//! - Configurable anchor alignment and custom position
+//! - Optional anchor offset for fine-tuned placement
+//! - Automatic removal of closed alerts from the vector
+//! - Scrollable area if alerts exceed the maximum height
+//!
+//! ## Note
+//! The alert manager is intended for use with the `Alert` widget and expects each alert to be a tuple of
+//! `(AlertLevel, String)`. You can push new alerts to the vector at any time, and they will be displayed
+//! until dismissed by the user.
+
+use egui::{Align2, Id, Order, ScrollArea, Ui, UiBuilder, Vec2, Widget, WidgetWithState};
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
+
+use crate::{Alert, AlertLevel};
+
+pub struct AlertManagerState {
+    pub alerts_rect: egui::Rect,
+}
+
+/// Manages and displays a list of alerts with shared styling and positioning.
+///
+/// See the [module-level documentation](self) for usage and configuration details.
+#[derive(Debug)]
+pub struct AlertManager<'a> {
+    /// Unique key for the alert manager instance (used for state management).
+    pub unique_key: String,
+    /// List of alerts as (level, message) tuples.
+    pub alerts: &'a mut Vec<(AlertLevel, String)>,
+    /// Default inner margin for alerts.
+    pub inner_margin: i8,
+    /// Default outer margin for alerts.
+    pub outer_margin: i8,
+    /// Default corner radius for alerts.
+    pub corner_radius: u8,
+    /// Default width for the alert area (optional).
+    pub width: Option<f32>,
+    /// Whether alerts can be closed.
+    pub can_close: bool,
+    /// Anchor position for the alert stack.
+    pub anchor: Align2,
+    /// Optional offset from the anchor position.
+    pub anchor_offset: Option<Vec2>,
+    /// Optional maximum height for the alert area (enables scrolling if exceeded).
+    pub max_height: Option<f32>,
+}
+
+impl<'a> AlertManager<'a> {
+    /// Create a new alert manager with a reference to a list of alerts.
+    pub fn new(alerts: &'a mut Vec<(AlertLevel, String)>, unique_key: &str) -> Self {
+        Self {
+            unique_key: format!("alert_manager_{}", unique_key),
+            alerts,
+            inner_margin: 10,
+            outer_margin: 1,
+            corner_radius: 4,
+            width: None,
+            can_close: true,
+            anchor: Align2::CENTER_TOP, // Default to top center
+            anchor_offset: None,
+            max_height: None,
+        }
+    }
+
+    /// Set the inner margin for all alerts.
+    pub fn inner_margin(mut self, margin: i8) -> Self {
+        self.inner_margin = margin;
+        self
+    }
+
+    /// Set the outer margin for all alerts.
+    pub fn outer_margin(mut self, margin: i8) -> Self {
+        self.outer_margin = margin;
+        self
+    }
+
+    /// Set the corner radius for all alerts.
+    pub fn corner_radius(mut self, radius: u8) -> Self {
+        self.corner_radius = radius;
+        self
+    }
+
+    /// Set the width for the alert area.
+    pub fn width(mut self, width: f32) -> Self {
+        self.width = Some(width);
+        self
+    }
+
+    /// Set whether alerts can be closed.
+    pub fn can_close(mut self, can_close: bool) -> Self {
+        self.can_close = can_close;
+        self
+    }
+
+    /// Set the anchor position for the alert stack.
+    pub fn anchor(mut self, anchor: Align2) -> Self {
+        let is_valid = matches!(
+            anchor,
+            Align2::LEFT_TOP
+                | Align2::CENTER_TOP
+                | Align2::RIGHT_TOP
+                | Align2::LEFT_BOTTOM
+                | Align2::CENTER_BOTTOM
+                | Align2::RIGHT_BOTTOM
+        );
+        assert!(
+            is_valid,
+            "Invalid anchor position: {:?}. We only support top or bottom anchors.",
+            anchor
+        );
+        self.anchor = anchor;
+        self
+    }
+
+    /// Set an offset from the anchor position.
+    pub fn anchor_offset(mut self, offset: Vec2) -> Self {
+        self.anchor_offset = Some(offset);
+        self
+    }
+
+    /// Set the maximum height for the alert area (enables scrolling if exceeded).
+    pub fn max_height(mut self, max_height: f32) -> Self {
+        self.max_height = Some(max_height);
+        self
+    }
+}
+
+impl<'a> WidgetWithState for AlertManager<'a> {
+    type State = AlertManagerState;
+}
+
+impl<'a> Widget for AlertManager<'a> {
+    fn ui(self, ui: &mut Ui) -> egui::Response {
+        let parent_area = ui.max_rect();
+        let mut to_remove = Vec::new();
+
+        // Generate a unique area for unique alert manager data
+        // TODO: this may be a memory leak
+        let mut hasher = DefaultHasher::new();
+        self.alerts.hash(&mut hasher);
+        let alerts_hash = hasher.finish();
+        let id: Id = Id::new(format!(
+            "{}_{}_{}_{}",
+            self.unique_key,
+            self.width.unwrap_or(-1.0),
+            self.max_height.unwrap_or(-1.0),
+            alerts_hash
+        ));
+
+        let is_bottom = self.anchor == Align2::LEFT_BOTTOM
+            || self.anchor == Align2::CENTER_BOTTOM
+            || self.anchor == Align2::RIGHT_BOTTOM;
+        let max_height = self
+            .max_height
+            .unwrap_or(parent_area.height())
+            .min(parent_area.height());
+        let max_width = self
+            .width
+            .unwrap_or(parent_area.width())
+            .min(parent_area.width());
+
+        let resp = egui::Area::new(id)
+            .order(Order::Foreground)
+            .anchor(self.anchor, self.anchor_offset.unwrap_or(Vec2::ZERO))
+            .constrain_to(parent_area)
+            .default_size(Vec2::new(max_width, max_height))
+            .show(ui.ctx(), |ui| {
+                if !ui.is_enabled() && !ui.is_visible() {
+                    for (level, message) in self.alerts.iter() {
+                        let mut alert = Alert::new(message)
+                            .with_level(*level)
+                            .inner_margin(self.inner_margin)
+                            .outer_margin(self.outer_margin)
+                            .corner_radius(self.corner_radius)
+                            .can_close(self.can_close);
+                        if self.width.is_some() {
+                            alert = alert.width(self.width.unwrap());
+                        }
+                        ui.add(alert);
+                    }
+                } else {
+                    // Normal pass: use ScrollArea
+                    let scroll_resp = ScrollArea::both()
+                        .stick_to_bottom(is_bottom)
+                        .max_height(max_height)
+                        .max_width(max_width)
+                        .show(ui, |ui| {
+                            let alert_iter: Box<
+                                dyn Iterator<Item = (usize, &(AlertLevel, String))>,
+                            > = if is_bottom {
+                                Box::new(self.alerts.iter().enumerate().rev())
+                            } else {
+                                Box::new(self.alerts.iter().enumerate())
+                            };
+
+                            for (idx, (level, message)) in alert_iter {
+                                let mut alert = Alert::new(message)
+                                    .with_level(*level)
+                                    .inner_margin(self.inner_margin)
+                                    .outer_margin(self.outer_margin)
+                                    .corner_radius(self.corner_radius)
+                                    .can_close(self.can_close);
+                                if self.width.is_some() {
+                                    alert = alert.width(self.width.unwrap());
+                                }
+                                let resp = ui.add(alert);
+                                if self.can_close && resp.clicked() {
+                                    to_remove.push(idx);
+                                }
+                            }
+
+                            for idx in to_remove.into_iter().rev() {
+                                self.alerts.remove(idx);
+                            }
+                        });
+                    scroll_resp.inner
+                }
+            })
+            .response;
+
+        resp
+    }
+}
+
+/// Convenience function to create an alert manager widget with a mutable vector of alerts.
+///
+/// # Parameters
+/// - `alerts`: A mutable reference to a vector of `(AlertLevel, String)` tuples representing the current alerts.
+///
+/// # Returns
+/// Returns an [`egui::Widget`] closure. When invoked, it returns an [`egui::Response`] for the alert manager area.
+///
+/// # Example
+/// ```
+/// # egui::__run_test_ui(|ui| {
+/// # let mut alerts = vec![(egui_widget_ext::AlertLevel::Info, "Hello!".to_string())];
+/// ui.add(egui_widget_ext::alert_manager(&mut alerts));
+/// # });
+/// ```
+pub fn alert_manager<'a>(alerts: &'a mut Vec<(AlertLevel, String)>) -> impl Widget + 'a {
+    move |ui: &mut Ui| AlertManager::new(alerts, "main").ui(ui)
+}

--- a/src/alert_manager.rs
+++ b/src/alert_manager.rs
@@ -26,12 +26,11 @@
 //! # use egui::{CentralPanel, Context};
 //! # fn ui_example(ctx: &Context, alerts: &mut Vec<(AlertLevel, String)>) {
 //! CentralPanel::default().show(ctx, |ui| {
-//!     AlertManager::new(alerts)
+//!     ui.add(AlertManager::new(alerts, "main")
 //!         .corner_radius(8)
 //!         .width(400.0)
 //!         .anchor(egui::Align2::CENTER_TOP)
-//!         .max_height(300.0)
-//!         .ui(ui);
+//!         .max_height(300.0));
 //! });
 //! # }
 //! ```
@@ -48,7 +47,6 @@
 //! `(AlertLevel, String)`. You can push new alerts to the vector at any time, and they will be displayed
 //! until dismissed by the user.
 
-use core::hash;
 use egui::{Align2, Id, Order, ScrollArea, Ui, Vec2, Widget};
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
@@ -56,8 +54,6 @@ use std::hash::{Hash, Hasher};
 use crate::{Alert, AlertLevel};
 
 /// Manages and displays a list of alerts with shared styling and positioning.
-///
-/// See the [module-level documentation](self) for usage and configuration details.
 #[derive(Debug)]
 pub struct AlertManager<'a> {
     /// Unique key for the alert manager instance (used for state management).

--- a/src/alert_manager.rs
+++ b/src/alert_manager.rs
@@ -48,15 +48,11 @@
 //! `(AlertLevel, String)`. You can push new alerts to the vector at any time, and they will be displayed
 //! until dismissed by the user.
 
-use egui::{Align2, Id, Order, ScrollArea, Ui, Vec2, Widget, WidgetWithState};
+use egui::{Align2, Id, Order, ScrollArea, Ui, Vec2, Widget};
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
 
 use crate::{Alert, AlertLevel};
-
-pub struct AlertManagerState {
-    pub alerts_rect: egui::Rect,
-}
 
 /// Manages and displays a list of alerts with shared styling and positioning.
 ///
@@ -165,10 +161,6 @@ impl<'a> AlertManager<'a> {
     }
 }
 
-impl<'a> WidgetWithState for AlertManager<'a> {
-    type State = AlertManagerState;
-}
-
 impl<'a> Widget for AlertManager<'a> {
     fn ui(self, ui: &mut Ui) -> egui::Response {
         let parent_area = ui.max_rect();
@@ -233,9 +225,11 @@ impl<'a> Widget for AlertManager<'a> {
                             let alert_iter: Box<
                                 dyn Iterator<Item = (usize, &(AlertLevel, String))>,
                             > = if is_bottom {
-                                Box::new(self.alerts.iter().enumerate().rev())
-                            } else {
+                                // FIFO order for bottom anchor so newest alerts appear at the bottom
                                 Box::new(self.alerts.iter().enumerate())
+                            } else {
+                                // LIFO order for top anchor so newest alerts appear at the top
+                                Box::new(self.alerts.iter().enumerate().rev())
                             };
 
                             // Iterate through alerts and render them

--- a/src/alert_manager.rs
+++ b/src/alert_manager.rs
@@ -48,6 +48,7 @@
 //! `(AlertLevel, String)`. You can push new alerts to the vector at any time, and they will be displayed
 //! until dismissed by the user.
 
+use core::hash;
 use egui::{Align2, Id, Order, ScrollArea, Ui, Vec2, Widget};
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
@@ -183,13 +184,13 @@ impl<'a> Widget for AlertManager<'a> {
     fn ui(self, ui: &mut Ui) -> egui::Response {
         let parent_area = ui.max_rect();
         let mut to_remove = Vec::new();
-        let id: Id = Id::new(self.unique_key.clone());
+        let hasher_id = Id::new(format!("alert_manager_hash_{}", self.unique_key));
         let mut hasher = DefaultHasher::new();
         self.hash(&mut hasher);
         let hash = hasher.finish();
-        let old_hash = ui.ctx().memory(|mem| mem.data.get_temp::<u64>(id));
+        let old_hash = ui.ctx().memory(|mem| mem.data.get_temp::<u64>(hasher_id));
         ui.ctx().memory_mut(|mem| {
-            mem.data.insert_temp(id, hash);
+            mem.data.insert_temp(hasher_id, hash);
         });
 
         // Determine best size limits
@@ -203,6 +204,7 @@ impl<'a> Widget for AlertManager<'a> {
             .clamp(1.0, parent_area.width());
 
         // Create floating area for the alert manager
+        let id: Id = Id::new(self.unique_key.clone());
         egui::Area::new(id)
             .order(Order::Foreground)
             .anchor(self.anchor, self.anchor_offset.unwrap_or(Vec2::ZERO))

--- a/src/alert_manager.rs
+++ b/src/alert_manager.rs
@@ -6,7 +6,7 @@
 //!
 //! ## Usage
 //!
-//! The `AlertManager` takes a mutable reference to a `Mutex<Vec<Alert>>` representing the current
+//! The `AlertManager` takes a reference to a `Mutex<Vec<Alert>>` representing the current
 //! alerts to display. It provides builder-style methods to configure margins, corner radius, width, anchor
 //! alignment, custom position, anchor offset, and maximum height for the alert area. Each alert is rendered
 //! using the `Alert` widget, and closed alerts are automatically removed from the vector.
@@ -25,7 +25,7 @@
 //! # use std::sync::Mutex;
 //! # use egui_widget_ext::{AlertManager, Alert};
 //! # use egui::{CentralPanel, Context};
-//! # fn ui_example(ctx: &Context, alerts: &mut Mutex<Vec<Alert>>) {
+//! # fn ui_example(ctx: &Context, alerts: &Mutex<Vec<Alert>>) {
 //! CentralPanel::default().show(ctx, |ui| {
 //!     ui.add(AlertManager::new(alerts, "main")
 //!         .corner_radius(8)
@@ -61,7 +61,7 @@ pub struct AlertManager<'a> {
     /// Unique key for the alert manager instance (used for state management).
     pub unique_key: String,
     /// List of alerts as (level, message) tuples.
-    pub alerts: &'a mut Mutex<Vec<Alert>>,
+    pub alerts: &'a Mutex<Vec<Alert>>,
     /// Default inner margin for alerts.
     pub inner_margin: i8,
     /// Default outer margin for alerts.
@@ -104,7 +104,7 @@ impl Hash for AlertManager<'_> {
 
 impl<'a> AlertManager<'a> {
     /// Create a new alert manager with a reference to a list of alerts.
-    pub fn new(alerts: &'a mut Mutex<Vec<Alert>>, unique_key: &str) -> Self {
+    pub fn new(alerts: &'a Mutex<Vec<Alert>>, unique_key: &str) -> Self {
         Self {
             unique_key: format!("alert_manager_{}", unique_key),
             alerts,
@@ -299,6 +299,6 @@ impl<'a> Widget for AlertManager<'a> {
 /// ui.add(egui_widget_ext::alert_manager(&mut alerts, "example_alerts"));
 /// # });
 /// ```
-pub fn alert_manager<'a>(alerts: &'a mut Mutex<Vec<Alert>>, unique_key: &str) -> AlertManager<'a> {
+pub fn alert_manager<'a>(alerts: &'a Mutex<Vec<Alert>>, unique_key: &str) -> AlertManager<'a> {
     AlertManager::new(alerts, unique_key)
 }

--- a/src/alert_manager.rs
+++ b/src/alert_manager.rs
@@ -22,6 +22,7 @@
 //!
 //! ## Example
 //! ```rust
+//! # use std::sync::Mutex;
 //! # use egui_widget_ext::{AlertManager, Alert};
 //! # use egui::{CentralPanel, Context};
 //! # fn ui_example(ctx: &Context, alerts: &mut Mutex<Vec<Alert>>) {
@@ -291,8 +292,10 @@ impl<'a> Widget for AlertManager<'a> {
 ///
 /// # Example
 /// ```
+/// # use std::sync::Mutex;
+/// # use egui_widget_ext::{alert_manager, Alert, AlertLevel};
 /// # egui::__run_test_ui(|ui| {
-/// # let mut alerts = vec![(egui_widget_ext::AlertLevel::Info, "Hello!".to_string())];
+/// # let mut alerts = Mutex::new(vec![Alert::new("Initial alert").with_level(AlertLevel::Info)]);
 /// ui.add(egui_widget_ext::alert_manager(&mut alerts, "example_alerts"));
 /// # });
 /// ```

--- a/src/alert_manager.rs
+++ b/src/alert_manager.rs
@@ -6,7 +6,7 @@
 //!
 //! ## Usage
 //!
-//! The `AlertManager` takes a reference to a `Mutex<Vec<Alert>>` representing the current
+//! The `AlertManager` takes a mutable reference to a `Vec<Alert>` representing the current
 //! alerts to display. It provides builder-style methods to configure margins, corner radius, width, anchor
 //! alignment, custom position, anchor offset, and maximum height for the alert area. Each alert is rendered
 //! using the `Alert` widget, and closed alerts are automatically removed from the vector.
@@ -22,10 +22,9 @@
 //!
 //! ## Example
 //! ```rust
-//! # use std::sync::Mutex;
 //! # use egui_widget_ext::{AlertManager, Alert};
 //! # use egui::{CentralPanel, Context};
-//! # fn ui_example(ctx: &Context, alerts: &Mutex<Vec<Alert>>) {
+//! # fn ui_example(ctx: &Context, alerts: &mut Vec<Alert>) {
 //! CentralPanel::default().show(ctx, |ui| {
 //!     ui.add(AlertManager::new(alerts, "main")
 //!         .corner_radius(8)
@@ -44,14 +43,13 @@
 //! - Scrollable area if alerts exceed the maximum height
 //!
 //! ## Note
-//! The alert manager is intended for use with the `Alert` widget and expects each alert to be a tuple of
+//! The alert manager is intended for use with the `Alert` widget and expects each alert to be an
 //! `Alert`. You can push new alerts to the vector at any time, and they will be displayed
 //! until dismissed by the user.
 
 use egui::{Align2, Id, Order, ScrollArea, Ui, Vec2, Widget};
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
-use std::sync::Mutex;
 
 use crate::Alert;
 
@@ -60,8 +58,8 @@ use crate::Alert;
 pub struct AlertManager<'a> {
     /// Unique key for the alert manager instance (used for state management).
     pub unique_key: String,
-    /// List of alerts as (level, message) tuples.
-    pub alerts: &'a Mutex<Vec<Alert>>,
+    /// List of alerts.
+    pub alerts: &'a mut Vec<Alert>,
     /// Default inner margin for alerts.
     pub inner_margin: i8,
     /// Default outer margin for alerts.
@@ -83,10 +81,8 @@ pub struct AlertManager<'a> {
 impl Hash for AlertManager<'_> {
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.unique_key.hash(state);
-        if let Ok(alerts) = self.alerts.try_lock() {
-            for a in alerts.iter() {
-                a.hash(state);
-            }
+        for a in self.alerts.iter() {
+            a.hash(state);
         }
         self.inner_margin.hash(state);
         self.outer_margin.hash(state);
@@ -104,7 +100,7 @@ impl Hash for AlertManager<'_> {
 
 impl<'a> AlertManager<'a> {
     /// Create a new alert manager with a reference to a list of alerts.
-    pub fn new(alerts: &'a Mutex<Vec<Alert>>, unique_key: &str) -> Self {
+    pub fn new(alerts: &'a mut Vec<Alert>, unique_key: &str) -> Self {
         Self {
             unique_key: format!("alert_manager_{}", unique_key),
             alerts,
@@ -217,19 +213,17 @@ impl<'a> Widget for AlertManager<'a> {
                 if !ui.is_enabled() && !ui.is_visible() {
                     // Detect sizing pass: do not use ScrollArea since that will hide the content size
                     // resulting in a chicken and egg problem.
-                    if let Ok(alerts) = self.alerts.try_lock() {
-                        for alert in alerts.iter() {
-                            let mut new_alert = alert
-                                .clone()
-                                .inner_margin(self.inner_margin)
-                                .outer_margin(self.outer_margin)
-                                .corner_radius(self.corner_radius)
-                                .can_close(self.can_close);
-                            if self.width.is_some() {
-                                new_alert = new_alert.width(self.width.unwrap());
-                            }
-                            ui.add(new_alert);
+                    for alert in self.alerts.iter() {
+                        let mut new_alert = alert
+                            .clone()
+                            .inner_margin(self.inner_margin)
+                            .outer_margin(self.outer_margin)
+                            .corner_radius(self.corner_radius)
+                            .can_close(self.can_close);
+                        if self.width.is_some() {
+                            new_alert = new_alert.width(self.width.unwrap());
                         }
+                        ui.add(new_alert);
                     }
                 } else {
                     let is_bottom = self.anchor == Align2::LEFT_BOTTOM
@@ -241,38 +235,34 @@ impl<'a> Widget for AlertManager<'a> {
                         .max_height(max_height)
                         .max_width(max_width)
                         .show(ui, |ui| {
-                            if let Ok(alerts) = self.alerts.try_lock().as_mut() {
-                                // Reverse alerts order if bottom anchor
-                                let alert_iter: Box<dyn Iterator<Item = (usize, &Alert)>> =
-                                    if is_bottom {
-                                        // FIFO order for bottom anchor so newest alerts appear at the bottom
-                                        Box::new(alerts.iter().enumerate())
-                                    } else {
-                                        // LIFO order for top anchor so newest alerts appear at the top
-                                        Box::new(alerts.iter().enumerate().rev())
-                                    };
+                            // Reverse alerts order if bottom anchor
+                            let alert_iter: Box<dyn Iterator<Item = (usize, &Alert)>> = if is_bottom
+                            {
+                                Box::new(self.alerts.iter().enumerate())
+                            } else {
+                                Box::new(self.alerts.iter().enumerate().rev())
+                            };
 
-                                // Iterate through alerts and render them
-                                for (idx, alert) in alert_iter {
-                                    let mut new_alert = alert
-                                        .clone()
-                                        .inner_margin(self.inner_margin)
-                                        .outer_margin(self.outer_margin)
-                                        .corner_radius(self.corner_radius)
-                                        .can_close(self.can_close);
-                                    if self.width.is_some() {
-                                        new_alert = new_alert.width(self.width.unwrap());
-                                    }
-                                    let resp = ui.add(new_alert);
-                                    if self.can_close && resp.clicked() {
-                                        to_remove.push(idx);
-                                    }
+                            // Iterate through alerts and render them
+                            for (idx, alert) in alert_iter {
+                                let mut new_alert = alert
+                                    .clone()
+                                    .inner_margin(self.inner_margin)
+                                    .outer_margin(self.outer_margin)
+                                    .corner_radius(self.corner_radius)
+                                    .can_close(self.can_close);
+                                if self.width.is_some() {
+                                    new_alert = new_alert.width(self.width.unwrap());
                                 }
+                                let resp = ui.add(new_alert);
+                                if self.can_close && resp.clicked() {
+                                    to_remove.push(idx);
+                                }
+                            }
 
-                                // Remove closed alerts in reverse order to avoid index shifting issues
-                                for idx in to_remove.into_iter().rev() {
-                                    alerts.remove(idx);
-                                }
+                            // Remove closed alerts in reverse order to avoid index shifting issues
+                            for idx in to_remove.into_iter().rev() {
+                                self.alerts.remove(idx);
                             }
                         });
                     scroll_resp.inner
@@ -283,22 +273,6 @@ impl<'a> Widget for AlertManager<'a> {
 }
 
 /// Convenience function to create an alert manager widget with a mutable vector of alerts.
-///
-/// # Parameters
-/// - `alerts`: A mutable reference to a vector of `Alert` tuples representing the current alerts.
-///
-/// # Returns
-/// Returns an `AlertManager` instance configured with the provided alerts.
-///
-/// # Example
-/// ```
-/// # use std::sync::Mutex;
-/// # use egui_widget_ext::{alert_manager, Alert, AlertLevel};
-/// # egui::__run_test_ui(|ui| {
-/// # let mut alerts = Mutex::new(vec![Alert::new("Initial alert").with_level(AlertLevel::Info)]);
-/// ui.add(egui_widget_ext::alert_manager(&mut alerts, "example_alerts"));
-/// # });
-/// ```
-pub fn alert_manager<'a>(alerts: &'a Mutex<Vec<Alert>>, unique_key: &str) -> AlertManager<'a> {
+pub fn alert_manager<'a>(alerts: &'a mut Vec<Alert>, unique_key: &str) -> AlertManager<'a> {
     AlertManager::new(alerts, unique_key)
 }

--- a/src/alert_manager.rs
+++ b/src/alert_manager.rs
@@ -212,7 +212,7 @@ impl<'a> Widget for AlertManager<'a> {
             .anchor(self.anchor, self.anchor_offset.unwrap_or(Vec2::ZERO))
             .constrain_to(parent_area)
             .default_size(Vec2::new(max_width, max_height))
-            .force_resize_to_content(old_hash.is_some() && old_hash.unwrap() != hash)
+            .sizing_pass(old_hash.is_some() && old_hash.unwrap() != hash)
             .show(ui.ctx(), |ui| {
                 if !ui.is_enabled() && !ui.is_visible() {
                     // Detect sizing pass: do not use ScrollArea since that will hide the content size

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,3 +20,7 @@ pub use alert::{Alert, AlertLevel, alert};
 mod toast;
 #[cfg(feature = "toast")]
 pub use toast::Toast;
+#[cfg(feature = "alert_manager")]
+mod alert_manager;
+#[cfg(feature = "alert_manager")]
+pub use alert_manager::{AlertManager, alert_manager};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,8 +19,12 @@ pub use alert::{Alert, AlertLevel, alert};
 #[cfg(feature = "toast")]
 mod toast;
 #[cfg(feature = "toast")]
-pub use toast::Toast;
+pub use toast::{Toast, toast};
 #[cfg(feature = "alert_manager")]
 mod alert_manager;
 #[cfg(feature = "alert_manager")]
 pub use alert_manager::{AlertManager, alert_manager};
+#[cfg(feature = "toast_manager")]
+mod toast_manager;
+#[cfg(feature = "toast_manager")]
+pub use toast_manager::{ToastManager, toast_manager};

--- a/src/toast.rs
+++ b/src/toast.rs
@@ -1,23 +1,27 @@
 //! # Toast Widget Module
 //!
-//! This module provides a customizable toast notification widget for use with the `egui` GUI library.
-//! Toasts are transient messages that appear for a short duration and then disappear automatically.
-//! They are useful for providing non-intrusive feedback to users, such as success messages, warnings, or errors.
+//! This module provides a customizable toast notification widget for use with the `egui` GUI
+//! library. Toasts are transient messages that appear for a short duration and then disappear
+//! automatically. They are useful for providing non-intrusive feedback to users, such as success
+//! messages.
 //!
 //! ## Usage
 //!
-//! The [`Toast`] struct allows you to configure the appearance, message, color, margins, corner radius, width, and duration of the toast.
-//! You can use the [`toast`] convenience function for a quick way to create a toast with a message.
+//! The [`Toast`] struct allows you to configure the appearance, message, color, margins, corner
+//! radius, width, and duration of the toast. You can use the [`toast`] convenience function for a
+//! quick way to create a toast with a message.
 //!
 //! **Important:**  
-//! Toasts rely on timeouts to disappear after a set duration. To ensure that the toast expires and disappears at the correct time,
-//! you should call `ctx.request_repaint_after(std::time::Duration::from_secs(1));` (or a similar interval) in your egui update loop.
-//! This ensures that egui continues to repaint even if there is no user interaction, allowing the toast to update and expire as expected.
+//! Toasts rely on timeouts to disappear after a set duration. To ensure that the toast expires and
+//! disappears at the correct time, you should call
+//! `ctx.request_repaint_after(std::time::Duration::from_secs(1));` (or a similar interval) in your
+//! egui update loop. This ensures that egui continues to repaint even if there is no user
+//! interaction, allowing the toast to update and expire as expected.
 //!
 //! ## Example
 //! ```
 //! # egui::__run_test_ui(|ui| {
-//! use egui_widget_ext::Toast;
+//! use egui_widget_ext::{Toast, toast};
 //! use egui::Color32;
 //! use std::time::Duration;
 //!
@@ -30,6 +34,9 @@
 //!     .width(300.0)
 //!     .duration(Duration::from_secs(5));
 //! ui.add(custom_toast);
+//!
+//! // Using the convenience function
+//! ui.add(toast("This is a default toast!"));
 //! # });
 //! ```
 //!
@@ -73,7 +80,7 @@ impl Default for Toast {
             message: "No message provided".to_string(),
             color: Color32::from_rgb(200, 200, 255), // Default to a blue color
             inner_margin: 10,
-            outer_margin: 10,
+            outer_margin: 1,
             corner_radius: 4,
             width: None,                      // Default to no specific width
             start_instant: Instant::now(),    // Start timing immediately
@@ -162,4 +169,23 @@ impl Widget for Toast {
             .inner;
         response
     }
+}
+
+/// Convenience function to create a toast with a message and default settings.
+///
+/// # Arguments
+/// - `message`: The message to display in the toast.
+///
+/// # Returns
+/// A new `Toast` instance with the specified message and default settings.
+///
+/// # Example
+/// ```
+/// # egui::__run_test_ui(|ui| {
+/// use egui_widget_ext::{toast};
+/// ui.add(toast("Success!"));
+/// # });
+/// ```
+pub fn toast(message: &str) -> Toast {
+    Toast::new(message)
 }

--- a/src/toast.rs
+++ b/src/toast.rs
@@ -54,7 +54,7 @@ use egui::{Color32, CornerRadius, Frame, Label, Margin, Response, RichText, Stro
 /// It supports setting the background color, message, inner and outer margins, corner radius, width,
 /// and the duration for which the toast should be visible. Toasts are intended to be temporary and
 /// will expire after the specified duration.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Toast {
     /// The message to display in the toast.
     pub message: String,

--- a/src/toast.rs
+++ b/src/toast.rs
@@ -14,7 +14,7 @@
 //! **Important:**  
 //! Toasts rely on timeouts to disappear after a set duration. To ensure that the toast expires and
 //! disappears at the correct time, you should call
-//! `ctx.request_repaint_after(std::time::Duration::from_secs(1));` (or a similar interval) in your
+//! `ctx.request_repaint_after(chrono::Duration::seconds(1).to_std().unwrap_or_default());` (or a similar interval) in your
 //! egui update loop. This ensures that egui continues to repaint even if there is no user
 //! interaction, allowing the toast to update and expire as expected.
 //!
@@ -23,7 +23,7 @@
 //! # egui::__run_test_ui(|ui| {
 //! use egui_widget_ext::{Toast, toast};
 //! use egui::Color32;
-//! use std::time::Duration;
+//! use chrono::Duration;
 //!
 //! // Using the struct directly and exercising all configuration methods
 //! let custom_toast = Toast::new("Custom toast")
@@ -32,7 +32,7 @@
 //!     .outer_margin(8)
 //!     .corner_radius(12)
 //!     .width(300.0)
-//!     .duration(Duration::from_secs(5));
+//!     .duration(Duration::seconds(5));
 //! ui.add(custom_toast);
 //!
 //! // Using the convenience function
@@ -44,7 +44,7 @@
 //! - [`Toast`]: Struct for configuring and displaying the toast widget.
 //! - [`toast`]: Convenience function for creating a toast widget.
 
-use std::time::{Duration, Instant};
+use chrono::{DateTime, Duration, Utc};
 
 use egui::{Color32, CornerRadius, Frame, Label, Margin, Response, RichText, Stroke, Ui, Widget};
 
@@ -69,7 +69,7 @@ pub struct Toast {
     /// Toast width, if specified.
     pub width: Option<f32>,
     /// Start instant for the toast, used for timing.
-    pub start_instant: Instant,
+    pub start_time: DateTime<Utc>,
     /// Duration for which the toast should be visible.
     pub duration: Duration,
 }
@@ -82,9 +82,9 @@ impl Default for Toast {
             inner_margin: 10,
             outer_margin: 1,
             corner_radius: 4,
-            width: None,                      // Default to no specific width
-            start_instant: Instant::now(),    // Start timing immediately
-            duration: Duration::from_secs(3), // Default duration of 3 seconds
+            width: None,                    // Default to no specific width
+            start_time: Utc::now(),         // Start timing immediately
+            duration: Duration::seconds(3), // Default duration of 3 seconds
         }
     }
 }
@@ -140,7 +140,7 @@ impl Toast {
     ///
     /// Returns `true` if the toast's duration has elapsed, otherwise `false`.
     pub fn has_expired(&self) -> bool {
-        self.start_instant.elapsed() >= self.duration
+        Utc::now().signed_duration_since(self.start_time) >= self.duration
     }
 }
 

--- a/src/toast_manager.rs
+++ b/src/toast_manager.rs
@@ -6,7 +6,7 @@
 //!
 //! ## Usage
 //!
-//! The `ToastManager` takes a mutable reference to a `VecDeque<Toast>` representing the current
+//! The `ToastManager` takes a mutable reference to a `Mutex<VecDeque<Toast>>` representing the current
 //! toasts to display. The widget provides builder-style methods to configure the maximum number of
 //! toasts, margins, corner radius, width, anchor alignment, and anchor offset. Each toast is
 //! rendered using the `Toast` widget trait. All anchor positions are relative to the screen, and
@@ -25,10 +25,11 @@
 //!
 //! ## Example
 //! ```rust
-//! # use egui_widget_ext::{ToastManager, Toast, toast, toast_manager};
 //! # use std::collections::VecDeque;
+//! # use std::sync::Mutex;
+//! # use egui_widget_ext::{ToastManager, Toast, toast, toast_manager};
 //! # fn ui_example(ui: &mut egui::Ui) {
-//! let mut toasts = VecDeque::from([
+//! let mut toasts = Mutex::new(VecDeque::from([
 //!     // Convenience function to create a default toast
 //!     toast("Saved successfully!"),
 //!     toast("Error occurred"),
@@ -40,7 +41,7 @@
 //!         .corner_radius(12)
 //!         .width(300.0)
 //!         .duration(std::time::Duration::from_secs(5)),
-//! ]);
+//! ]));
 //! // Add a manager that allows up to 3 toasts at once
 //! ui.add(ToastManager::new(&mut toasts, "main").max_toasts(3));
 //! // Add a separate manager using the convenience function
@@ -56,7 +57,7 @@
 //! - Each toast can have its own duration
 //!
 //! ## Note
-//! - The `ToastManager` widget is designed to use a mutable reference to a `VecDeque<Toast>`
+//! - The `ToastManager` widget is designed to use a mutable reference to a `Mutex<VecDeque<Toast>>`
 //! but manager settings are used to override the default appearance of all toasts.
 //! - A scroll area in not supported in this widget as toasts are typically transient and low
 //! volume at any given time.
@@ -65,6 +66,7 @@
 //!
 
 use std::collections::VecDeque;
+use std::sync::Mutex;
 
 use egui::Widget;
 
@@ -75,7 +77,7 @@ pub struct ToastManager<'a> {
     unique_key: String,
     /// Mutable reference to the deque of toasts, where each toast is a tuple of (message, duration).
     /// A reference is used so this content can be easily hoisted to a higher scope if desired.
-    toasts: &'a mut VecDeque<Toast>,
+    toasts: &'a mut Mutex<VecDeque<Toast>>,
     /// Maximum number of toasts to display at once.
     max_toasts: usize,
     /// Inner margin (padding) for the toast area.
@@ -93,7 +95,7 @@ pub struct ToastManager<'a> {
 }
 
 impl<'a> ToastManager<'a> {
-    pub fn new(toasts: &'a mut VecDeque<Toast>, unique_key: &str) -> Self {
+    pub fn new(toasts: &'a mut Mutex<VecDeque<Toast>>, unique_key: &str) -> Self {
         Self {
             unique_key: format!("toast_manager_{}", unique_key),
             toasts,
@@ -162,13 +164,19 @@ impl<'a> ToastManager<'a> {
 
 impl<'a> Widget for ToastManager<'a> {
     fn ui(self, ui: &mut egui::Ui) -> egui::Response {
+        let Ok(mut toasts_guard) = self.toasts.try_lock() else {
+            // If we can't lock the toasts, return an empty response
+            return ui.allocate_response(egui::Vec2::ZERO, egui::Sense::hover());
+        };
+        let toasts = &mut *toasts_guard;
+
         // Remove expired toasts
-        self.toasts.retain(|toast| !toast.has_expired());
+        toasts.retain(|toast| !toast.has_expired());
 
         // Ensure we don't exceed the maximum number of toasts
-        while self.toasts.len() > self.max_toasts {
+        while toasts.len() > self.max_toasts {
             // Remove the oldest toast if we exceed the limit
-            self.toasts.pop_front();
+            toasts.pop_front();
         }
 
         let parent_area = ui.max_rect();
@@ -178,9 +186,9 @@ impl<'a> Widget for ToastManager<'a> {
             || self.anchor == egui::Align2::CENTER_BOTTOM;
 
         let toast_iter: Box<dyn Iterator<Item = &Toast>> = if is_bottom {
-            Box::new(self.toasts.iter().rev()) // Show newest toasts at the bottom
+            Box::new(toasts.iter()) // Show newest toasts at the top
         } else {
-            Box::new(self.toasts.iter()) // Show oldest toasts at the top
+            Box::new(toasts.iter().rev()) // Show newest toasts at the top
         };
 
         egui::Area::new(egui::Id::new(self.unique_key))
@@ -216,15 +224,16 @@ impl<'a> Widget for ToastManager<'a> {
 ///
 /// # Example
 /// ```
-/// # use egui_widget_ext::{ToastManager, toast, toast_manager};
 /// # use std::collections::VecDeque;
+/// # use std::sync::Mutex;
+/// # use egui_widget_ext::{ToastManager, toast, toast_manager};
 /// # egui::__run_test_ui(|ui| {
-/// let mut toasts = VecDeque::from([toast("Hello, World!")]);
+/// let mut toasts = Mutex::new(VecDeque::from([toast("Hello, World!")]));
 /// ui.add(toast_manager(&mut toasts, "main"));
 /// # });
 /// ```
 pub fn toast_manager<'a>(
-    toasts: &'a mut std::collections::VecDeque<Toast>,
+    toasts: &'a mut Mutex<VecDeque<Toast>>,
     unique_key: &str,
 ) -> ToastManager<'a> {
     ToastManager::new(toasts, unique_key)

--- a/src/toast_manager.rs
+++ b/src/toast_manager.rs
@@ -6,7 +6,7 @@
 //!
 //! ## Usage
 //!
-//! The `ToastManager` takes a mutable reference to a `Mutex<VecDeque<Toast>>` representing the current
+//! The `ToastManager` takes a reference to a `Mutex<VecDeque<Toast>>` representing the current
 //! toasts to display. The widget provides builder-style methods to configure the maximum number of
 //! toasts, margins, corner radius, width, anchor alignment, and anchor offset. Each toast is
 //! rendered using the `Toast` widget trait. All anchor positions are relative to the screen, and
@@ -43,9 +43,9 @@
 //!         .duration(std::time::Duration::from_secs(5)),
 //! ]));
 //! // Add a manager that allows up to 3 toasts at once
-//! ui.add(ToastManager::new(&mut toasts, "main").max_toasts(3));
+//! ui.add(ToastManager::new(&toasts, "main").max_toasts(3));
 //! // Add a separate manager using the convenience function
-//! ui.add(toast_manager(&mut toasts, "main1"));
+//! ui.add(toast_manager(&toasts, "main1"));
 //! # }
 //! ```
 //!
@@ -77,7 +77,7 @@ pub struct ToastManager<'a> {
     unique_key: String,
     /// Mutable reference to the deque of toasts, where each toast is a tuple of (message, duration).
     /// A reference is used so this content can be easily hoisted to a higher scope if desired.
-    toasts: &'a mut Mutex<VecDeque<Toast>>,
+    toasts: &'a Mutex<VecDeque<Toast>>,
     /// Maximum number of toasts to display at once.
     max_toasts: usize,
     /// Inner margin (padding) for the toast area.
@@ -95,7 +95,7 @@ pub struct ToastManager<'a> {
 }
 
 impl<'a> ToastManager<'a> {
-    pub fn new(toasts: &'a mut Mutex<VecDeque<Toast>>, unique_key: &str) -> Self {
+    pub fn new(toasts: &'a Mutex<VecDeque<Toast>>, unique_key: &str) -> Self {
         Self {
             unique_key: format!("toast_manager_{}", unique_key),
             toasts,
@@ -229,12 +229,9 @@ impl<'a> Widget for ToastManager<'a> {
 /// # use egui_widget_ext::{ToastManager, toast, toast_manager};
 /// # egui::__run_test_ui(|ui| {
 /// let mut toasts = Mutex::new(VecDeque::from([toast("Hello, World!")]));
-/// ui.add(toast_manager(&mut toasts, "main"));
+/// ui.add(toast_manager(&toasts, "main"));
 /// # });
 /// ```
-pub fn toast_manager<'a>(
-    toasts: &'a mut Mutex<VecDeque<Toast>>,
-    unique_key: &str,
-) -> ToastManager<'a> {
+pub fn toast_manager<'a>(toasts: &'a Mutex<VecDeque<Toast>>, unique_key: &str) -> ToastManager<'a> {
     ToastManager::new(toasts, unique_key)
 }

--- a/src/toast_manager.rs
+++ b/src/toast_manager.rs
@@ -1,0 +1,226 @@
+//! # Toast Manager Widget Module
+//!
+//! This module provides a `ToastManager` widget for managing and displaying temporary toast
+//! notifications in an egui application. Toasts are short-lived, non-blocking messages that
+//! appear in a corner of the UI and automatically disappear after a set duration.
+//!
+//! ## Usage
+//!
+//! The `ToastManager` takes a mutable reference to a `VecDeque<Toast>` representing the current
+//! toasts to display. The widget provides builder-style methods to configure the maximum number of
+//! toasts, margins, corner radius, width, anchor alignment, and anchor offset. Each toast is
+//! rendered using the `Toast` widget trait. All anchor positions are relative to the screen, and
+//! NOT the parent area.
+//!
+//! The manager ensures that only up to `max_toasts` are displayed at once, automatically removing
+//! the oldest toasts as new ones are added. Toasts are typically used for transient feedback.
+//!
+//! **Important:**  
+//! Toasts rely on timeouts to disappear after a set duration. To ensure that the toast expires and
+//! disappears at the correct time, you should call
+//! `ctx.request_repaint_after(std::time::Duration::from_secs(1));` (or a similar interval) in your
+//! egui update loop. This ensures that egui continues to repaint even if there is no user
+//! interaction, allowing the toast to update and expire as expected.
+//!
+//!
+//! ## Example
+//! ```rust
+//! # use egui_widget_ext::{ToastManager, toast, toast_manager};
+//! # use std::collections::VecDeque;
+//! # fn ui_example(ui: &mut egui::Ui) {
+//! let mut toasts = VecDeque::from([
+//!     // Convenience function to create a default toast
+//!     toast("Saved successfully!".to_string()),
+//!     toast("Error occurred".to_string()),
+//!     // Custom toast with specific styling
+//!     Toast::new("This is a custom toast!")
+//!         .with_color(egui::Color32::from_rgb(255, 200, 200))
+//!         .inner_margin(16)
+//!         .outer_margin(8)
+//!         .corner_radius(12)
+//!         .width(300.0)
+//!         .duration(std::time::Duration::from_secs(5)),
+//! ]);
+//! // Add a manager that allows up to 3 toasts at once
+//! ui.add(ToastManager::new(&mut toasts, "main").max_toasts(3));
+//! // Add a separate manager using the convenience function
+//! ui.add(toast_manager(&mut toasts));
+//! # }
+//! ```
+//!
+//! ## Features
+//! - Configurable maximum number of toasts
+//! - Shared styling for all toasts (margin, corner radius, width, etc.)
+//! - Configurable anchor alignment and offset
+//! - Automatic removal of oldest toasts when limit is exceeded
+//! - Each toast can have its own duration
+//!
+//! ## Note
+//! - The `ToastManager` widget is designed to use a mutable reference to a `VecDeque<Toast>`
+//! but manager settings are used to override the default appearance of all toasts.
+//! - A scroll area in not supported in this widget as toasts are typically transient and low
+//! volume at any given time.
+//! - the provided width is clamped to parent height if it exceeds the available space or 1.0 if it
+//! is less than 0.0. We use 1.0 to ensure something is shown to indicate that there are toasts.
+//!
+
+use std::collections::VecDeque;
+
+use egui::Widget;
+
+use crate::Toast;
+
+pub struct ToastManager<'a> {
+    /// Unique key for the toast manager area, used to prevent conflicts with other areas.
+    unique_key: String,
+    /// Mutable reference to the deque of toasts, where each toast is a tuple of (message, duration).
+    /// A reference is used so this content can be easily hoisted to a higher scope if desired.
+    toasts: &'a mut VecDeque<Toast>,
+    /// Maximum number of toasts to display at once.
+    max_toasts: usize,
+    /// Inner margin (padding) for the toast area.
+    inner_margin: i8,
+    /// Outer margin for the toast area.
+    outer_margin: i8,
+    /// Corner radius for the toast area.
+    corner_radius: u8,
+    /// Width of the toast area.
+    width: f32,
+    /// Anchor position for the toast area.
+    anchor: egui::Align2,
+    /// Offset from the anchor position for the toast area.
+    anchor_offset: egui::Vec2,
+}
+
+impl<'a> ToastManager<'a> {
+    pub fn new(toasts: &'a mut VecDeque<Toast>, unique_key: &str) -> Self {
+        Self {
+            unique_key: format!("toast_manager_{}", unique_key),
+            toasts,
+            max_toasts: 1,
+            inner_margin: 5,
+            outer_margin: 1,
+            corner_radius: 4,
+            width: 200.0,
+            anchor: egui::Align2::RIGHT_BOTTOM,
+            anchor_offset: egui::Vec2::ZERO,
+        }
+    }
+
+    /// Set the maximum number of toasts to display.
+    pub fn max_toasts(mut self, max: usize) -> Self {
+        self.max_toasts = max;
+        self
+    }
+
+    /// Set the inner margin for all alerts.
+    pub fn inner_margin(mut self, margin: i8) -> Self {
+        self.inner_margin = margin;
+        self
+    }
+
+    /// Set the outer margin for all alerts.
+    pub fn outer_margin(mut self, margin: i8) -> Self {
+        self.outer_margin = margin;
+        self
+    }
+
+    /// Set the corner radius for all alerts.
+    pub fn corner_radius(mut self, radius: u8) -> Self {
+        self.corner_radius = radius;
+        self
+    }
+
+    /// Set the width for the alert area.
+    pub fn width(mut self, width: f32) -> Self {
+        self.width = width;
+        self
+    }
+
+    /// Set the anchor position for the toast area.
+    pub fn anchor(mut self, anchor: egui::Align2) -> Self {
+        assert!(
+            anchor == egui::Align2::RIGHT_BOTTOM
+                || anchor == egui::Align2::LEFT_BOTTOM
+                || anchor == egui::Align2::CENTER_BOTTOM
+                || anchor == egui::Align2::RIGHT_TOP
+                || anchor == egui::Align2::LEFT_TOP
+                || anchor == egui::Align2::CENTER_TOP,
+            "Invalid anchor position for ToastManager. Must be one of: RIGHT_BOTTOM, LEFT_BOTTOM,\
+             CENTER_BOTTOM, RIGHT_TOP, LEFT_TOP, CENTER_TOP."
+        );
+        self.anchor = anchor;
+        self
+    }
+
+    /// Set the anchor offset for the toast area.
+    pub fn anchor_offset(mut self, offset: egui::Vec2) -> Self {
+        self.anchor_offset = offset;
+        self
+    }
+}
+
+impl<'a> Widget for ToastManager<'a> {
+    fn ui(self, ui: &mut egui::Ui) -> egui::Response {
+        // Remove expired toasts
+        self.toasts.retain(|toast| !toast.has_expired());
+
+        // Ensure we don't exceed the maximum number of toasts
+        while self.toasts.len() > self.max_toasts {
+            // Remove the oldest toast if we exceed the limit
+            self.toasts.pop_front();
+        }
+
+        let parent_area = ui.max_rect();
+        let width = self.width.clamp(1.0, parent_area.width());
+        let is_bottom = self.anchor == egui::Align2::RIGHT_BOTTOM
+            || self.anchor == egui::Align2::LEFT_BOTTOM
+            || self.anchor == egui::Align2::CENTER_BOTTOM;
+
+        let toast_iter: Box<dyn Iterator<Item = &Toast>> = if is_bottom {
+            Box::new(self.toasts.iter().rev()) // Show newest toasts at the bottom
+        } else {
+            Box::new(self.toasts.iter()) // Show oldest toasts at the top
+        };
+
+        egui::Area::new(egui::Id::new(self.unique_key))
+            .anchor(self.anchor, self.anchor_offset)
+            .show(ui.ctx(), |ui| {
+                // Create a vertical layout for the toasts
+                ui.vertical(|ui| {
+                    // Iterate over the toasts and display them
+                    for toast in toast_iter {
+                        let toast = toast
+                            .clone()
+                            .inner_margin(self.inner_margin)
+                            .outer_margin(self.outer_margin)
+                            .corner_radius(self.corner_radius)
+                            .width(width);
+
+                        toast.ui(ui);
+                    }
+                });
+            })
+            .response
+    }
+}
+
+/// Convenience function to create a toast manager widget with a mutable VecDeque of toasts.
+///
+/// # Parameters
+/// - `toasts`: A mutable reference to a VecDeque of `(String, f32)` tuples representing the current
+///   toasts.
+///
+/// # Returns
+/// A `ToastManager` instance configured with the provided toasts.
+///
+/// # Example
+/// ```
+/// # egui::__run_test_ui(|ui| {
+/// # let mut toasts = VecDeque::from([(String::from("Hello!"), 2.0)]);
+/// ui.add(egui_widget_ext::toast_manager(&mut toasts));
+/// # });
+/// ```
+pub fn toast_manager<'a>(toasts: &'a mut std::collections::VecDeque<Toast>) -> ToastManager<'a> {
+    ToastManager::new(toasts, "main")
+}

--- a/src/toast_manager.rs
+++ b/src/toast_manager.rs
@@ -25,13 +25,13 @@
 //!
 //! ## Example
 //! ```rust
-//! # use egui_widget_ext::{ToastManager, toast, toast_manager};
+//! # use egui_widget_ext::{ToastManager, Toast, toast, toast_manager};
 //! # use std::collections::VecDeque;
 //! # fn ui_example(ui: &mut egui::Ui) {
 //! let mut toasts = VecDeque::from([
 //!     // Convenience function to create a default toast
-//!     toast("Saved successfully!".to_string()),
-//!     toast("Error occurred".to_string()),
+//!     toast("Saved successfully!"),
+//!     toast("Error occurred"),
 //!     // Custom toast with specific styling
 //!     Toast::new("This is a custom toast!")
 //!         .with_color(egui::Color32::from_rgb(255, 200, 200))
@@ -216,9 +216,11 @@ impl<'a> Widget for ToastManager<'a> {
 ///
 /// # Example
 /// ```
+/// # use egui_widget_ext::{ToastManager, toast, toast_manager};
+/// # use std::collections::VecDeque;
 /// # egui::__run_test_ui(|ui| {
-/// # let mut toasts = VecDeque::from([(String::from("Hello!"), 2.0)]);
-/// ui.add(egui_widget_ext::toast_manager(&mut toasts, "main"));
+/// let mut toasts = VecDeque::from([toast("Hello, World!")]);
+/// ui.add(toast_manager(&mut toasts, "main"));
 /// # });
 /// ```
 pub fn toast_manager<'a>(

--- a/src/toast_manager.rs
+++ b/src/toast_manager.rs
@@ -44,7 +44,7 @@
 //! // Add a manager that allows up to 3 toasts at once
 //! ui.add(ToastManager::new(&mut toasts, "main").max_toasts(3));
 //! // Add a separate manager using the convenience function
-//! ui.add(toast_manager(&mut toasts));
+//! ui.add(toast_manager(&mut toasts, "main1"));
 //! # }
 //! ```
 //!
@@ -218,9 +218,12 @@ impl<'a> Widget for ToastManager<'a> {
 /// ```
 /// # egui::__run_test_ui(|ui| {
 /// # let mut toasts = VecDeque::from([(String::from("Hello!"), 2.0)]);
-/// ui.add(egui_widget_ext::toast_manager(&mut toasts));
+/// ui.add(egui_widget_ext::toast_manager(&mut toasts, "main"));
 /// # });
 /// ```
-pub fn toast_manager<'a>(toasts: &'a mut std::collections::VecDeque<Toast>) -> ToastManager<'a> {
-    ToastManager::new(toasts, "main")
+pub fn toast_manager<'a>(
+    toasts: &'a mut std::collections::VecDeque<Toast>,
+    unique_key: &str,
+) -> ToastManager<'a> {
+    ToastManager::new(toasts, unique_key)
 }

--- a/src/toast_manager.rs
+++ b/src/toast_manager.rs
@@ -6,7 +6,7 @@
 //!
 //! ## Usage
 //!
-//! The `ToastManager` takes a reference to a `Mutex<VecDeque<Toast>>` representing the current
+//! The `ToastManager` takes a mutable reference to a `VecDeque<Toast>` representing the current
 //! toasts to display. The widget provides builder-style methods to configure the maximum number of
 //! toasts, margins, corner radius, width, anchor alignment, and anchor offset. Each toast is
 //! rendered using the `Toast` widget trait. All anchor positions are relative to the screen, and
@@ -25,28 +25,27 @@
 //!
 //! ## Example
 //! ```rust
-//! # use std::collections::VecDeque;
-//! # use std::sync::Mutex;
-//! # use egui_widget_ext::{ToastManager, Toast, toast, toast_manager};
-//! # fn ui_example(ui: &mut egui::Ui) {
-//! let mut toasts = Mutex::new(VecDeque::from([
-//!     // Convenience function to create a default toast
-//!     toast("Saved successfully!"),
-//!     toast("Error occurred"),
-//!     // Custom toast with specific styling
-//!     Toast::new("This is a custom toast!")
-//!         .with_color(egui::Color32::from_rgb(255, 200, 200))
-//!         .inner_margin(16)
-//!         .outer_margin(8)
-//!         .corner_radius(12)
-//!         .width(300.0)
-//!         .duration(std::time::Duration::from_secs(5)),
-//! ]));
-//! // Add a manager that allows up to 3 toasts at once
-//! ui.add(ToastManager::new(&toasts, "main").max_toasts(3));
-//! // Add a separate manager using the convenience function
-//! ui.add(toast_manager(&toasts, "main1"));
-//! # }
+//! use std::collections::VecDeque;
+//! use egui_widget_ext::{ToastManager, Toast, toast, toast_manager};
+//! fn ui_example(ui: &mut egui::Ui) {
+//!     let mut toasts = VecDeque::from([
+//!         // Convenience function to create a default toast
+//!         toast("Saved successfully!"),
+//!         toast("Error occurred"),
+//!         // Custom toast with specific styling
+//!         Toast::new("This is a custom toast!")
+//!             .with_color(egui::Color32::from_rgb(255, 200, 200))
+//!             .inner_margin(16)
+//!             .outer_margin(8)
+//!             .corner_radius(12)
+//!             .width(300.0)
+//!             .duration(std::time::Duration::from_secs(5)),
+//!     ]);
+//!     // Add a manager that allows up to 3 toasts at once
+//!     ui.add(ToastManager::new(&mut toasts, "main").max_toasts(3));
+//!     // Add a separate manager using the convenience function
+//!     ui.add(toast_manager(&mut toasts, "main1"));
+//! }
 //! ```
 //!
 //! ## Features
@@ -57,16 +56,15 @@
 //! - Each toast can have its own duration
 //!
 //! ## Note
-//! - The `ToastManager` widget is designed to use a mutable reference to a `Mutex<VecDeque<Toast>>`
-//! but manager settings are used to override the default appearance of all toasts.
-//! - A scroll area in not supported in this widget as toasts are typically transient and low
-//! volume at any given time.
-//! - the provided width is clamped to parent height if it exceeds the available space or 1.0 if it
-//! is less than 0.0. We use 1.0 to ensure something is shown to indicate that there are toasts.
+//! - The `ToastManager` widget is designed to use a mutable reference to a `VecDeque<Toast>`.
+//!   Manager settings are used to override the default appearance of all toasts.
+//! - A scroll area is not supported in this widget as toasts are typically transient and low
+//!   volume at any given time.
+//! - The provided width is clamped to parent height if it exceeds the available space or 1.0 if it
+//!   is less than 0.0. We use 1.0 to ensure something is shown to indicate that there are toasts.
 //!
 
 use std::collections::VecDeque;
-use std::sync::Mutex;
 
 use egui::Widget;
 
@@ -75,27 +73,19 @@ use crate::Toast;
 pub struct ToastManager<'a> {
     /// Unique key for the toast manager area, used to prevent conflicts with other areas.
     unique_key: String,
-    /// Mutable reference to the deque of toasts, where each toast is a tuple of (message, duration).
-    /// A reference is used so this content can be easily hoisted to a higher scope if desired.
-    toasts: &'a Mutex<VecDeque<Toast>>,
-    /// Maximum number of toasts to display at once.
+    /// Mutable reference to the deque of toasts.
+    toasts: &'a mut VecDeque<Toast>,
     max_toasts: usize,
-    /// Inner margin (padding) for the toast area.
     inner_margin: i8,
-    /// Outer margin for the toast area.
     outer_margin: i8,
-    /// Corner radius for the toast area.
     corner_radius: u8,
-    /// Width of the toast area.
     width: f32,
-    /// Anchor position for the toast area.
     anchor: egui::Align2,
-    /// Offset from the anchor position for the toast area.
     anchor_offset: egui::Vec2,
 }
 
 impl<'a> ToastManager<'a> {
-    pub fn new(toasts: &'a Mutex<VecDeque<Toast>>, unique_key: &str) -> Self {
+    pub fn new(toasts: &'a mut VecDeque<Toast>, unique_key: &str) -> Self {
         Self {
             unique_key: format!("toast_manager_{}", unique_key),
             toasts,
@@ -164,19 +154,12 @@ impl<'a> ToastManager<'a> {
 
 impl<'a> Widget for ToastManager<'a> {
     fn ui(self, ui: &mut egui::Ui) -> egui::Response {
-        let Ok(mut toasts_guard) = self.toasts.try_lock() else {
-            // If we can't lock the toasts, return an empty response
-            return ui.allocate_response(egui::Vec2::ZERO, egui::Sense::hover());
-        };
-        let toasts = &mut *toasts_guard;
-
         // Remove expired toasts
-        toasts.retain(|toast| !toast.has_expired());
+        self.toasts.retain(|toast| !toast.has_expired());
 
         // Ensure we don't exceed the maximum number of toasts
-        while toasts.len() > self.max_toasts {
-            // Remove the oldest toast if we exceed the limit
-            toasts.pop_front();
+        while self.toasts.len() > self.max_toasts {
+            self.toasts.pop_front();
         }
 
         let parent_area = ui.max_rect();
@@ -186,17 +169,15 @@ impl<'a> Widget for ToastManager<'a> {
             || self.anchor == egui::Align2::CENTER_BOTTOM;
 
         let toast_iter: Box<dyn Iterator<Item = &Toast>> = if is_bottom {
-            Box::new(toasts.iter()) // Show newest toasts at the top
+            Box::new(self.toasts.iter())
         } else {
-            Box::new(toasts.iter().rev()) // Show newest toasts at the top
+            Box::new(self.toasts.iter().rev())
         };
 
         egui::Area::new(egui::Id::new(self.unique_key))
             .anchor(self.anchor, self.anchor_offset)
             .show(ui.ctx(), |ui| {
-                // Create a vertical layout for the toasts
                 ui.vertical(|ui| {
-                    // Iterate over the toasts and display them
                     for toast in toast_iter {
                         let toast = toast
                             .clone()
@@ -204,7 +185,6 @@ impl<'a> Widget for ToastManager<'a> {
                             .outer_margin(self.outer_margin)
                             .corner_radius(self.corner_radius)
                             .width(width);
-
                         toast.ui(ui);
                     }
                 });
@@ -224,14 +204,13 @@ impl<'a> Widget for ToastManager<'a> {
 ///
 /// # Example
 /// ```
-/// # use std::collections::VecDeque;
-/// # use std::sync::Mutex;
-/// # use egui_widget_ext::{ToastManager, toast, toast_manager};
-/// # egui::__run_test_ui(|ui| {
-/// let mut toasts = Mutex::new(VecDeque::from([toast("Hello, World!")]));
-/// ui.add(toast_manager(&toasts, "main"));
-/// # });
+/// use std::collections::VecDeque;
+/// use egui_widget_ext::{ToastManager, toast, toast_manager};
+/// egui::__run_test_ui(|ui| {
+///     let mut toasts = VecDeque::from([toast("Hello, World!")]);
+///     ui.add(toast_manager(&mut toasts, "main"));
+/// });
 /// ```
-pub fn toast_manager<'a>(toasts: &'a Mutex<VecDeque<Toast>>, unique_key: &str) -> ToastManager<'a> {
+pub fn toast_manager<'a>(toasts: &'a mut VecDeque<Toast>, unique_key: &str) -> ToastManager<'a> {
     ToastManager::new(toasts, unique_key)
 }

--- a/src/toast_manager.rs
+++ b/src/toast_manager.rs
@@ -39,7 +39,7 @@
 //!             .outer_margin(8)
 //!             .corner_radius(12)
 //!             .width(300.0)
-//!             .duration(std::time::Duration::from_secs(5)),
+//!             .duration(chrono::Duration::seconds(5)),
 //!     ]);
 //!     // Add a manager that allows up to 3 toasts at once
 //!     ui.add(ToastManager::new(&mut toasts, "main").max_toasts(3));


### PR DESCRIPTION
Add support for an alert and toast manager.

The alerts manager is the most complex with the use of an overlay area that must frequently change size to fit the content so as to support interaction with area not covered by the actual alerts yet allow them to be constrained by a parent widget. This requires resetting Area size state which is not standard practice.